### PR TITLE
Modular Wait For

### DIFF
--- a/mantis_sdk/space.py
+++ b/mantis_sdk/space.py
@@ -92,9 +92,11 @@ class Space:
                             timeout=self.config.timeout)
             
             await self._apply_init_render_args ()
+
+            wait_for = self.config.wait_for if hasattr(self.config, 'wait_for') else "isLoaded"
             
             # Wait until the exposed loading value is true
-            await self.page.wait_for_function ("""() => window.isLoaded === true""",
+            await self.page.wait_for_function (f"""() => window.{wait_for} === true""",
                                          timeout=self.config.timeout)
             
             # Let points render after data is loaded


### PR DESCRIPTION
This pull request makes a targeted improvement to the space initialization process by allowing the loading condition to be configurable. Instead of always waiting for `window.isLoaded`, the code now checks a configurable property, improving flexibility for different use cases.

Key change:

* Made the loading wait condition configurable by using `self.config.wait_for` if available, defaulting to `"isLoaded"`; updated the JavaScript wait function accordingly in `_init_space` in `mantis_sdk/space.py`.