### PR TITLE
Fix f-string syntax error

### DIFF
--- a/mantis_sdk/client.py
+++ b/mantis_sdk/client.py
@@ -270,7 +270,7 @@ class MantisClient:
                 raise SpaceCreationError (progress["error"])
 
             if progress["progress"] != previous_progress:
-                print(f"{progress["progress"]}% - {progress['message']}")
+                print(f"{progress['progress']}% - {progress['message']}")
                 previous_progress = progress["progress"]
                         
             # Detects whether we need to select some params


### PR DESCRIPTION
Fixes syntax error in f-string on line 273 of client.py that was preventing SDK from loading.