### PR TITLE
Agents provider scoping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,25 @@
 This project follows [Semantic Versioning](https://semver.org/). Breaking changes bump the minor
 version while pre-1.0.
 
+## [0.12.0] — 2026-06-14
+
+### Added
+- **Agent runtime, provider-scoped** (`client.agents`). Run `opencode` (default, universal) or
+  `claude_code` (opt-in, capability-gated) agents scoped to a space, streaming normalized events.
+  - `client.agents.session(space_id, provider=..., user_email=...)` → async streaming
+    `AgentSession`; `run.ask(...)` yields `AgentEvent`s (`text`/`tool_use`/`tool_result`/`thinking`/
+    `complete`/`fail`); `run.result()` assembles an `AgentResult`.
+  - `client.agents.run_sync(...)` sync convenience.
+  - `client.agents.providers(email)` / `set_provider(email, provider)` over
+    `/agent_execution/providers/`.
+  - New `Provider` enum (`OpenCode`, `ClaudeCode`); `Provider.OpenCode` is the default.
+  - `ProviderUnavailableError` raised up front when `claude_code` isn't `bedrock_enabled`
+    (no silent fallback), and on detecting the run reported a different provider than requested.
+  - `AgentRunError` for mid-stream failures / timeouts.
+  - `ConfigurationManager.user_email` (or `MANTIS_USER_EMAIL`) — the agent runtime keys identity
+    + capability gating on email, not user_id.
+  - Contract verified live against `ws/chat/<chat_id>/<email>/default/?model_id=<provider>`.
+
 ## [0.11.0] — 2026-06-11
 
 ### Fixed (compatibility with current MantisAPI)

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ print(space.get_annotations())
 | `client.spaces` | `create(...)`, `from_github(repo_url)`, `get_all()`, `aopen(space_id)` |
 | `client.maps` | `list(space_id)`, `list_idea_ids(map_id)`, `get_ideas(ids)` |
 | `client.notebooks` | `resolve_map_to_project`, `create`, `from_map` |
+| `client.agents` | `session(...)`, `run_sync(...)`, `providers(email)`, `set_provider(email, provider)` |
 | `client.annotations` | `list(map_id)`, `create(map_id, payload)` |
 | `client.search` | `cluster_questions(...)` *(backend route currently disabled)* |
 
@@ -94,6 +95,36 @@ open("plot.png", "wb").write(plot.image_png_bytes())
 nb.checkpoint("after-plot")          # snapshot kernel state
 nb.list_checkpoints()
 ```
+
+## Agents (provider-scoped)
+
+Run a coding agent scoped to a space, streaming its output. Two runtime providers:
+`Provider.OpenCode` (the **default**, available to everyone) and `Provider.ClaudeCode`
+(opt-in — the user must have `bedrock_enabled` capabilities; the SDK checks this up front and
+raises `ProviderUnavailableError` rather than silently downgrading).
+
+The agent runtime identifies the user by **email** (set `config.user_email` or pass `user_email=`),
+not user_id.
+
+```python
+from mantis_sdk import Provider
+
+async with client.agents.session(space_id, provider=Provider.OpenCode, user_email=email) as run:
+    async for ev in run.ask("Summarize the outlier cluster", active_map_id=map_id):
+        if ev.type == "text":      print(ev.text, end="")
+        elif ev.type == "tool_use": print("→", ev.tool_name)
+    result = run.result()          # full text + events; result.provider asserts the runtime used
+
+# sync convenience
+result = client.agents.run_sync("What patterns are here?", space_id, provider=Provider.OpenCode,
+                                user_email=email)
+
+# capability management
+client.agents.providers(email)                     # {providers, default, current}
+client.agents.set_provider(email, Provider.ClaudeCode)
+```
+
+Event types: `text`, `tool_use`, `tool_result`, `thinking`, `init`, `typing`, `complete`, `fail`.
 
 ## Browser automation
 

--- a/examples/agent_run.py
+++ b/examples/agent_run.py
@@ -1,0 +1,46 @@
+"""run an agent (opencode by default, claude_code opt-in) scoped to a space, streaming output.
+
+auth: a browser session cookie in MANTIS_COOKIE. the agent runtime identifies the user by
+EMAIL (MANTIS_USER_EMAIL), not user_id. claude_code additionally requires that user to have
+bedrock_enabled in their capabilities — the SDK checks this up front and raises
+ProviderUnavailableError instead of silently downgrading."""
+import asyncio
+import os
+
+from mantis_sdk import ConfigurationManager, MantisClient, Provider
+from mantis_sdk.exceptions import ProviderUnavailableError
+
+config = ConfigurationManager().update({
+    "host": os.getenv("MANTIS_HOST", "http://localhost:3000"),
+    "backend_host": os.getenv("MANTIS_BACKEND_HOST", "http://localhost:8000"),
+    "user_email": os.environ["MANTIS_USER_EMAIL"],
+})
+client = MantisClient("/api/proxy/", cookie=os.environ["MANTIS_COOKIE"], config=config)
+
+SPACE_ID = os.getenv("MANTIS_SPACE_ID")  # optional: scope the agent to a space/map
+PROVIDER = Provider(os.getenv("MANTIS_PROVIDER", "opencode"))  # opencode is the safe default
+
+
+async def main():
+    # which providers can this user actually use?
+    print("providers:", client.agents.providers(config.user_email))
+
+    try:
+        async with client.agents.session(SPACE_ID, provider=PROVIDER) as run:
+            print(f"[running with {PROVIDER}]")
+            async for ev in run.ask("Give me a one-sentence summary of this space."):
+                if ev.type == "text":
+                    print(ev.text, end="", flush=True)
+                elif ev.type == "tool_use":
+                    print(f"\n  → tool: {ev.tool_name}", flush=True)
+                elif ev.type == "fail":
+                    print(f"\n[run failed] {ev.text}", flush=True)
+            print()
+            result = run.result()
+            print(f"[done] provider={result.provider} failed={result.failed}")
+    except ProviderUnavailableError as exc:
+        # e.g. claude_code requested but the user isn't bedrock_enabled.
+        print(f"[provider unavailable] {exc}")
+
+
+asyncio.run(main())

--- a/mantis_sdk/__init__.py
+++ b/mantis_sdk/__init__.py
@@ -1,10 +1,12 @@
 """Mantis SDK — pythonic client for the Mantis frontend + backend."""
 from __future__ import annotations
 
+from .agents import AgentEvent, AgentResult, AgentSession
 from .client import MantisClient
 from .config import ConfigurationManager
-from .enums import AIProvider, DataType, ReducerModels, SpacePrivacy
+from .enums import AIProvider, DataType, Provider, ReducerModels, SpacePrivacy
 from .exceptions import (
+    AgentRunError,
     APIConnectionError,
     APIStatusError,
     AuthenticationError,
@@ -13,6 +15,7 @@ from .exceptions import (
     FeatureUnavailableError,
     MantisError,
     NotFoundError,
+    ProviderUnavailableError,
     RateLimitError,
     SpaceCreationError,
 )
@@ -20,7 +23,7 @@ from .notebook import Cell, Notebook
 from .render_args import RenderArgs
 from .resources import SpaceHandle
 
-__version__ = "0.11.0"
+__version__ = "0.12.0"
 
 
 def __getattr__(name: str):
@@ -40,11 +43,16 @@ __all__ = [
     "SpaceHandle",
     "Notebook",
     "Cell",
+    # agents
+    "AgentSession",
+    "AgentEvent",
+    "AgentResult",
     # enums
     "DataType",
     "SpacePrivacy",
     "ReducerModels",
     "AIProvider",
+    "Provider",
     # exceptions
     "MantisError",
     "ConfigurationError",
@@ -56,5 +64,7 @@ __all__ = [
     "SpaceCreationError",
     "FeatureUnavailableError",
     "ExecutionError",
+    "ProviderUnavailableError",
+    "AgentRunError",
     "__version__",
 ]

--- a/mantis_sdk/agents.py
+++ b/mantis_sdk/agents.py
@@ -1,0 +1,298 @@
+"""agent runtime: run claude_code / opencode agents scoped to a space, streaming results.
+
+verified against the live backend (orchestration/composer + agent_execution):
+  - transport: websocket ws/chat/<chat_id>/<url-encoded-email>/default/?model_id=<provider>
+    (the email-in-path route resolves identity so claude_code capability gating works;
+    the bare ws/chat/?space_id= route leaves user_email=None and can't gate claude_code).
+  - provider is selected per run via `model_id` (per-message overrides connect-time).
+  - opencode is universally available; claude_code requires UserCapabilities.bedrock_enabled.
+  - wire events: typing_indicator, chat_messages (assistant text), tool_use, tool_result,
+    thinking, agent_session_init, then terminal chat_complete / chat_fail. events echo
+    `provider`, so we can assert the run actually used the requested runtime.
+  - capability REST: GET /agent_execution/providers/?user_email=, POST .../providers/set/.
+
+opencode is the safe default. claude_code is opt-in and capability-checked up front so we
+raise ProviderUnavailableError instead of letting the backend silently fall back."""
+from __future__ import annotations
+
+import json
+import logging
+import time
+import uuid
+from collections.abc import AsyncIterator
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+from urllib.parse import quote
+
+from .enums import Provider
+from .exceptions import AgentRunError, ConfigurationError, ProviderUnavailableError
+
+if TYPE_CHECKING:
+    from .resources import MantisClientProtocol
+
+logger = logging.getLogger("mantis_sdk")
+
+# terminal wire events that end a run.
+_TERMINAL = frozenset({"chat_complete", "chat_fail"})
+# wire event types the sdk understands; anything else is passed through as type="other".
+_TEXT_TYPES = frozenset({"chat_messages"})
+
+
+@dataclass
+class AgentEvent:
+    """a single normalized event from an agent run.
+
+    type is one of: text, tool_use, tool_result, thinking, init, typing, complete, fail, other.
+    raw holds the original wire dict for anything not surfaced as a field."""
+
+    type: str
+    text: str = ""
+    tool_name: str | None = None
+    provider: str | None = None
+    raw: dict = field(default_factory=dict)
+
+    @classmethod
+    def from_wire(cls, data: dict) -> AgentEvent:
+        wire = data.get("type", "")
+        provider = data.get("provider")
+        if wire in _TEXT_TYPES:
+            return cls("text", text=data.get("content", "") or "", provider=provider, raw=data)
+        if wire == "tool_use":
+            return cls("tool_use", tool_name=data.get("tool_name") or data.get("name"),
+                       provider=provider, raw=data)
+        if wire == "tool_result":
+            return cls("tool_result", text=str(data.get("content", "") or ""),
+                       tool_name=data.get("tool_name"), provider=provider, raw=data)
+        if wire == "thinking":
+            return cls("thinking", text=data.get("content", "") or "", provider=provider, raw=data)
+        if wire == "agent_session_init":
+            return cls("init", provider=provider, raw=data)
+        if wire == "typing_indicator":
+            return cls("typing", provider=provider, raw=data)
+        if wire == "chat_complete":
+            return cls("complete", text=data.get("content", "") or "", provider=provider, raw=data)
+        if wire == "chat_fail":
+            return cls("fail", text=data.get("content", "") or "", provider=provider, raw=data)
+        return cls("other", provider=provider, raw=data)
+
+    @property
+    def is_terminal(self) -> bool:
+        return self.type in ("complete", "fail")
+
+
+@dataclass
+class AgentResult:
+    """the assembled outcome of a run: full assistant text + the events that produced it."""
+
+    text: str
+    provider: str
+    events: list[AgentEvent]
+    failed: bool = False
+    error: str | None = None
+
+
+class AgentSession:
+    """an async, streaming agent run scoped to a space and a provider.
+
+    usage:
+        async with client.agents.session(space_id, provider=Provider.OpenCode,
+                                         user_email=email) as run:
+            async for ev in run.ask("..."):
+                ...
+            result = run.result()
+    """
+
+    def __init__(self, resource: AgentsResource, *, user_email: str, provider: Provider,
+                 space_id: str | None, chat_id: str, timeout: float):
+        self._resource = resource
+        self.user_email = user_email
+        self.provider = Provider(provider)
+        self.space_id = space_id
+        self.chat_id = chat_id
+        self.timeout = timeout
+        self._ws = None
+        self._events: list[AgentEvent] = []
+
+    def _ws_url(self) -> str:
+        cfg = self._resource.http.config
+        host = cfg.backend_host or cfg.host
+        ws_base = host.replace("https://", "wss://").replace("http://", "ws://").rstrip("/")
+        url = f"{ws_base}/ws/chat/{self.chat_id}/{quote(self.user_email, safe='')}/default/?model_id={self.provider.value}"
+        if self.space_id:
+            url += f"&space_id={self.space_id}"
+        return url
+
+    async def __aenter__(self) -> AgentSession:
+        import websockets
+
+        cookie = self._resource.http.cookie
+        headers = {"Cookie": cookie} if cookie else None
+        self._ws = await websockets.connect(
+            self._ws_url(), additional_headers=headers, max_size=None, open_timeout=self.timeout
+        )
+        return self
+
+    async def __aexit__(self, *exc: Any) -> None:
+        await self.close()
+
+    async def close(self) -> None:
+        if self._ws is not None:
+            await self._ws.close()
+            self._ws = None
+
+    async def ask(self, message: str, *, active_map_id: str | None = None,
+                  bag_ids: list[str] | None = None, cluster_ids: list[str] | None = None,
+                  generate_suggestions: bool = False) -> AsyncIterator[AgentEvent]:
+        """send a message and yield normalized events until the run terminates.
+
+        model_id is sent on the message so the provider scoping is explicit per run; the
+        backend echoes `provider` on events and we assert it matches what we asked for."""
+        import asyncio
+
+        if self._ws is None:
+            raise ConfigurationError("AgentSession must be used as an async context manager")
+
+        payload: dict[str, Any] = {
+            "message": message,
+            "model_id": self.provider.value,
+            "generate_suggestions": generate_suggestions,
+        }
+        if active_map_id:
+            payload["active_map_id"] = active_map_id
+        if bag_ids:
+            payload["bagIds"] = bag_ids
+        if cluster_ids:
+            payload["clusterIds"] = cluster_ids
+
+        await self._ws.send(json.dumps(payload))
+
+        deadline = time.monotonic() + self.timeout
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise AgentRunError(f"agent run timed out after {self.timeout}s")
+            try:
+                raw = await asyncio.wait_for(self._ws.recv(), timeout=remaining)
+            except asyncio.TimeoutError as exc:
+                raise AgentRunError(f"agent run timed out after {self.timeout}s") from exc
+
+            try:
+                data = json.loads(raw)
+            except (ValueError, TypeError):
+                continue
+            if not isinstance(data, dict):
+                continue
+
+            event = AgentEvent.from_wire(data)
+            # assert the backend didn't silently route to a different runtime.
+            if event.provider and event.provider != self.provider.value:
+                raise ProviderUnavailableError(
+                    f"requested provider {self.provider.value!r} but the run reported "
+                    f"{event.provider!r}; the backend may have fallen back."
+                )
+            self._events.append(event)
+            yield event
+            if event.is_terminal:
+                return
+
+    def result(self) -> AgentResult:
+        """assemble the full assistant text + outcome from the events seen so far."""
+        text = "".join(e.text for e in self._events if e.type in ("text", "complete"))
+        failed = any(e.type == "fail" for e in self._events)
+        error = next((e.text for e in self._events if e.type == "fail"), None)
+        return AgentResult(text=text, provider=self.provider.value, events=list(self._events),
+                           failed=failed, error=error)
+
+
+class AgentsResource:
+    """run agents and manage per-user provider capabilities. exposed as client.agents."""
+
+    DEFAULT_PROVIDER = Provider.OpenCode
+
+    def __init__(self, client: MantisClientProtocol):
+        self._client = client
+        self.http = client.http
+
+    # --- capabilities (REST) ---
+    def providers(self, user_email: str) -> dict:
+        """list the providers available to a user. shape: {providers, default, current}."""
+        return self.http.request(
+            "GET", "/agent_execution/providers", params={"user_email": user_email}, rm_slash=False
+        )
+
+    def set_provider(self, user_email: str, provider: Provider | str) -> dict:
+        """set the user's default provider (persisted in UserCapabilities)."""
+        return self.http.request(
+            "POST", "/agent_execution/providers/set",
+            json={"user_email": user_email, "provider": str(provider)},
+        )
+
+    def _assert_available(self, user_email: str, provider: Provider) -> None:
+        """raise ProviderUnavailableError up front if the user can't use this provider.
+        opencode is always available, so we only check the gated claude_code path."""
+        if provider == Provider.OpenCode:
+            return
+        try:
+            info = self.providers(user_email)
+        except Exception as exc:  # noqa: BLE001 — treat a failed check as a hard stop, with context
+            raise ProviderUnavailableError(
+                f"could not verify provider availability for {user_email!r}: {exc}"
+            ) from exc
+        available = set(info.get("providers", [])) if isinstance(info, dict) else set()
+        if provider.value not in available:
+            raise ProviderUnavailableError(
+                f"provider {provider.value!r} is not available for {user_email!r} "
+                f"(available: {sorted(available)}). claude_code requires bedrock_enabled "
+                f"on the user's capabilities."
+            )
+
+    # --- runs ---
+    def session(self, space_id: str | None = None, *,
+                provider: Provider | str = DEFAULT_PROVIDER,
+                user_email: str | None = None,
+                chat_id: str | None = None,
+                timeout: float = 180.0,
+                check_capability: bool = True) -> AgentSession:
+        """open a streaming agent session. opencode by default; claude_code is checked up front.
+
+        user_email is required (identity for capability gating); falls back to MANTIS_USER_EMAIL
+        via the config's internal_user_id is NOT valid here — agents key on email, not user_id."""
+        provider = Provider(provider)
+        user_email = user_email or getattr(self.http.config, "user_email", None)
+        if not user_email:
+            raise ConfigurationError(
+                "agents.session requires user_email (the agent runtime keys capability + identity "
+                "on email, not user_id)."
+            )
+        if check_capability:
+            self._assert_available(user_email, provider)
+        return AgentSession(
+            self, user_email=user_email, provider=provider, space_id=space_id,
+            chat_id=chat_id or f"sdk-{uuid.uuid4()}", timeout=timeout,
+        )
+
+    def run_sync(self, message: str, space_id: str | None = None, *,
+                 provider: Provider | str = DEFAULT_PROVIDER,
+                 user_email: str | None = None,
+                 timeout: float = 180.0,
+                 on_event=None, **ask_kwargs) -> AgentResult:
+        """synchronous convenience: run one message to completion and return the result.
+        on_event(ev) is called for each streamed event if provided."""
+        import asyncio
+
+        async def _run() -> AgentResult:
+            async with self.session(space_id, provider=provider, user_email=user_email,
+                                    timeout=timeout) as run:
+                async for ev in run.ask(message, **ask_kwargs):
+                    if on_event is not None:
+                        on_event(ev)
+                return run.result()
+
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            return asyncio.run(_run())
+        raise ConfigurationError(
+            "run_sync cannot be called from a running event loop; use `async with "
+            "client.agents.session(...)` instead."
+        )

--- a/mantis_sdk/agents.py
+++ b/mantis_sdk/agents.py
@@ -9,7 +9,7 @@ verified against the live backend (orchestration/composer + agent_execution):
   - wire events: typing_indicator, chat_messages (assistant text), tool_use, tool_result,
     thinking, agent_session_init, then terminal chat_complete / chat_fail. events echo
     `provider`, so we can assert the run actually used the requested runtime.
-  - capability REST: GET /agent_execution/providers/?user_email=, POST .../providers/set/.
+  - capability REST: GET /api/agent_execution/providers/?user_email=, POST .../providers/set/.
 
 opencode is the safe default. claude_code is opt-in and capability-checked up front so we
 raise ProviderUnavailableError instead of letting the backend silently fall back."""
@@ -214,16 +214,18 @@ class AgentsResource:
         self.http = client.http
 
     # --- capabilities (REST) ---
+    # routes are mounted under api/ (backend/urls.py: path('api/', include('agent_execution.urls'))),
+    # so the proxy-relative path is /api/agent_execution/...
     def providers(self, user_email: str) -> dict:
         """list the providers available to a user. shape: {providers, default, current}."""
         return self.http.request(
-            "GET", "/agent_execution/providers", params={"user_email": user_email}, rm_slash=False
+            "GET", "/api/agent_execution/providers", params={"user_email": user_email}
         )
 
     def set_provider(self, user_email: str, provider: Provider | str) -> dict:
         """set the user's default provider (persisted in UserCapabilities)."""
         return self.http.request(
-            "POST", "/agent_execution/providers/set",
+            "POST", "/api/agent_execution/providers/set",
             json={"user_email": user_email, "provider": str(provider)},
         )
 

--- a/mantis_sdk/client.py
+++ b/mantis_sdk/client.py
@@ -13,10 +13,11 @@ from typing import Any
 import pandas as pd
 
 from ._http import HttpClient
+from .agents import AgentsResource
 from .config import ConfigurationManager
 
 # re-exported for back-compat: legacy code imports these enums from mantis_sdk.client.
-from .enums import AIProvider, DataType, ReducerModels, SpacePrivacy
+from .enums import AIProvider, DataType, Provider, ReducerModels, SpacePrivacy
 from .exceptions import ConfigurationError
 from .notebook import NotebooksResource
 from .resources import (
@@ -38,6 +39,7 @@ __all__ = [
     "SpacePrivacy",
     "ReducerModels",
     "AIProvider",
+    "Provider",
 ]
 
 
@@ -67,6 +69,7 @@ class MantisClient:
         self.annotations = AnnotationsResource(self)
         self.search = SearchResource(self)
         self.notebooks = NotebooksResource(self)
+        self.agents = AgentsResource(self)
 
     # --- constructors ---
     @classmethod

--- a/mantis_sdk/config.py
+++ b/mantis_sdk/config.py
@@ -30,6 +30,10 @@ class ConfigurationManager:
         # X-Internal-Service: true and X-Internal-User-Id headers.
         self.internal_user_id: str | None = os.getenv("MANTIS_INTERNAL_USER_ID")
 
+        # the agent runtime (client.agents) keys identity + capability gating on email, not
+        # user_id. set this (or MANTIS_USER_EMAIL) so agents.session() can default user_email.
+        self.user_email: str | None = os.getenv("MANTIS_USER_EMAIL")
+
         self.render_args = RenderArgs(
             {
                 "headless": True,

--- a/mantis_sdk/enums.py
+++ b/mantis_sdk/enums.py
@@ -54,3 +54,10 @@ class ReducerModels(StrEnum):
     UMAP = "UMAP"
     PCA = "PCA+UMAP"
     TSNE = "t-SNE"
+
+
+class Provider(StrEnum):
+    # agent-execution runtime providers, sent to the backend as `model_id` per run.
+    # opencode is universally available; claude_code requires UserCapabilities.bedrock_enabled.
+    OpenCode = "opencode"
+    ClaudeCode = "claude_code"

--- a/mantis_sdk/exceptions.py
+++ b/mantis_sdk/exceptions.py
@@ -51,3 +51,12 @@ class FeatureUnavailableError(MantisError):
 
 class ExecutionError(MantisError):
     """raised when a notebook cell execution fails or times out."""
+
+
+class ProviderUnavailableError(MantisError):
+    """raised when an agent provider isn't usable for the user (e.g. claude_code without
+    bedrock_enabled). prevents the backend's silent fallback to the default provider."""
+
+
+class AgentRunError(MantisError):
+    """raised when an agent run fails mid-stream (the backend emits a chat_fail event)."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mantis_sdk"
-version = "0.11.0"
+version = "0.12.0"
 description = "Pythonic SDK for interacting with the Mantis frontend + backend"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -50,7 +50,7 @@ def test_opencode_never_calls_capability_check(client, transport):
 def test_claude_code_allowed_when_in_providers(client, transport):
     transport.queue = [{"providers": ["opencode", "claude_code"], "default": "opencode"}]
     client.agents._assert_available("u@e.com", Provider.ClaudeCode)  # no raise
-    assert transport.calls[0]["url"].endswith("/agent_execution/providers/")
+    assert transport.calls[0]["url"].endswith("/api/agent_execution/providers/")
 
 
 def test_claude_code_blocked_when_not_available(client, transport):
@@ -72,7 +72,7 @@ def test_set_provider_posts_correct_body(client, transport):
     transport.queue = [{"current": "claude_code", "providers": ["opencode", "claude_code"]}]
     client.agents.set_provider("u@e.com", Provider.ClaudeCode)
     call = transport.calls[0]
-    assert call["url"].endswith("/agent_execution/providers/set/")
+    assert call["url"].endswith("/api/agent_execution/providers/set/")
     assert call["kwargs"]["json"] == {"user_email": "u@e.com", "provider": "claude_code"}
 
 

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -1,0 +1,187 @@
+"""agent runtime tests — fully mocked, no live websocket / agent infra.
+
+we drive AgentSession against a fake websocket that replays the exact event stream the
+live backend produced during recon (typing_indicator → chat_messages → chat_complete /
+chat_fail), and stub the capability REST endpoint via the recording transport."""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from mantis_sdk import (
+    AgentEvent,
+    Provider,
+    ProviderUnavailableError,
+)
+from mantis_sdk.agents import AgentResult, AgentsResource
+
+# --- event normalization (pure, no IO) ---
+
+def test_event_from_wire_text():
+    ev = AgentEvent.from_wire({"type": "chat_messages", "content": "hello", "provider": "opencode"})
+    assert ev.type == "text" and ev.text == "hello" and ev.provider == "opencode"
+
+
+def test_event_from_wire_tool_use():
+    ev = AgentEvent.from_wire({"type": "tool_use", "tool_name": "search", "provider": "claude_code"})
+    assert ev.type == "tool_use" and ev.tool_name == "search"
+
+
+def test_event_from_wire_terminal():
+    assert AgentEvent.from_wire({"type": "chat_complete"}).is_terminal
+    assert AgentEvent.from_wire({"type": "chat_fail", "content": "boom"}).is_terminal
+    assert not AgentEvent.from_wire({"type": "typing_indicator"}).is_terminal
+
+
+def test_event_from_wire_unknown_passes_through():
+    ev = AgentEvent.from_wire({"type": "some_new_event", "x": 1})
+    assert ev.type == "other" and ev.raw["x"] == 1
+
+
+# --- capability gating (REST via recording transport) ---
+
+def test_opencode_never_calls_capability_check(client, transport):
+    # opencode is universal; _assert_available must not hit the network for it.
+    client.agents._assert_available("u@e.com", Provider.OpenCode)
+    assert transport.calls == []
+
+
+def test_claude_code_allowed_when_in_providers(client, transport):
+    transport.queue = [{"providers": ["opencode", "claude_code"], "default": "opencode"}]
+    client.agents._assert_available("u@e.com", Provider.ClaudeCode)  # no raise
+    assert transport.calls[0]["url"].endswith("/agent_execution/providers/")
+
+
+def test_claude_code_blocked_when_not_available(client, transport):
+    transport.queue = [{"providers": ["opencode"], "default": "opencode"}]
+    with pytest.raises(ProviderUnavailableError, match="claude_code"):
+        client.agents._assert_available("u@e.com", Provider.ClaudeCode)
+
+
+def test_capability_check_failure_is_hard_stop(client, transport):
+    def boom(method, url, kwargs):
+        raise RuntimeError("network down")
+
+    transport.responder = boom
+    with pytest.raises(ProviderUnavailableError, match="could not verify"):
+        client.agents._assert_available("u@e.com", Provider.ClaudeCode)
+
+
+def test_set_provider_posts_correct_body(client, transport):
+    transport.queue = [{"current": "claude_code", "providers": ["opencode", "claude_code"]}]
+    client.agents.set_provider("u@e.com", Provider.ClaudeCode)
+    call = transport.calls[0]
+    assert call["url"].endswith("/agent_execution/providers/set/")
+    assert call["kwargs"]["json"] == {"user_email": "u@e.com", "provider": "claude_code"}
+
+
+def test_session_requires_user_email(client):
+    with pytest.raises(Exception, match="user_email"):
+        client.agents.session("space1", provider=Provider.OpenCode, check_capability=False)
+
+
+# --- streaming run against a fake websocket ---
+
+class _FakeWS:
+    """minimal async websocket double: records sends, replays a scripted event list on recv."""
+
+    def __init__(self, script):
+        self._script = [json.dumps(e) for e in script]
+        self.sent = []
+        self.closed = False
+
+    async def send(self, data):
+        self.sent.append(json.loads(data))
+
+    async def recv(self):
+        if not self._script:
+            raise AssertionError("recv called after script exhausted")
+        return self._script.pop(0)
+
+    async def close(self):
+        self.closed = True
+
+
+def _session(client, provider=Provider.OpenCode, script=None):
+    sess = client.agents.session(
+        "space1", provider=provider, user_email="u@e.com",
+        check_capability=False, timeout=5,
+    )
+    sess._ws = _FakeWS(script or [])
+    return sess
+
+
+@pytest.mark.asyncio
+async def test_ask_streams_events_and_assembles_result(client):
+    script = [
+        {"type": "typing_indicator", "is_typing": True},
+        {"type": "chat_messages", "content": "Hello ", "provider": "opencode"},
+        {"type": "chat_messages", "content": "world", "provider": "opencode"},
+        {"type": "chat_complete", "content": "", "provider": "opencode"},
+    ]
+    sess = _session(client, script=script)
+    types = []
+    async for ev in sess.ask("hi"):
+        types.append(ev.type)
+    # the message we sent must carry the provider as model_id.
+    assert sess._ws.sent[0]["model_id"] == "opencode"
+    assert sess._ws.sent[0]["message"] == "hi"
+    assert types == ["typing", "text", "text", "complete"]
+    result = sess.result()
+    assert isinstance(result, AgentResult)
+    assert result.text == "Hello world"
+    assert result.failed is False
+
+
+@pytest.mark.asyncio
+async def test_ask_raises_on_provider_mismatch(client):
+    # backend silently routed to a different runtime → we refuse to pretend it worked.
+    script = [{"type": "chat_messages", "content": "x", "provider": "claude_code"}]
+    sess = _session(client, provider=Provider.OpenCode, script=script)
+    with pytest.raises(ProviderUnavailableError, match="fallen back"):
+        async for _ in sess.ask("hi"):
+            pass
+
+
+@pytest.mark.asyncio
+async def test_ask_surfaces_chat_fail(client):
+    script = [
+        {"type": "chat_messages", "content": "partial", "provider": "opencode"},
+        {"type": "chat_fail", "content": "Incorrect API key", "provider": "opencode"},
+    ]
+    sess = _session(client, script=script)
+    async for _ in sess.ask("hi"):
+        pass
+    result = sess.result()
+    assert result.failed is True
+    assert "Incorrect API key" in result.error
+
+
+@pytest.mark.asyncio
+async def test_ask_sends_map_and_bag_scoping(client):
+    script = [{"type": "chat_complete", "provider": "opencode"}]
+    sess = _session(client, script=script)
+    async for _ in sess.ask("hi", active_map_id="m1", bag_ids=["b1"], cluster_ids=["c1"]):
+        pass
+    sent = sess._ws.sent[0]
+    assert sent["active_map_id"] == "m1"
+    assert sent["bagIds"] == ["b1"]
+    assert sent["clusterIds"] == ["c1"]
+
+
+def test_ws_url_uses_email_path_and_provider(client):
+    sess = client.agents.session(
+        "space1", provider=Provider.ClaudeCode, user_email="a+b@e.com",
+        check_capability=False,
+    )
+    url = sess._ws_url()
+    # email is url-encoded in the path; provider is the model_id; space is a query param.
+    assert "/ws/chat/" in url and "/default/" in url
+    assert "a%2Bb%40e.com" in url
+    assert "model_id=claude_code" in url
+    assert "space_id=space1" in url
+
+
+def test_default_provider_is_opencode():
+    assert AgentsResource.DEFAULT_PROVIDER == Provider.OpenCode


### PR DESCRIPTION
This pull request introduces a new agent runtime to the SDK, allowing users to run coding agents (either `opencode` or, if permitted, `claude_code`) scoped to a space with streaming output. The agent runtime is provider-scoped, supports capability management, and identifies users by email. The SDK now exposes these features through a new `client.agents` interface, with both async and sync APIs, and raises explicit errors for unavailable providers. Documentation and examples are updated accordingly.

Agent runtime and provider management:

* Added new agent runtime under `client.agents`, supporting provider-scoped agent runs (default: `opencode`, opt-in: `claude_code`), with streaming of normalized events via async context manager (`AgentSession`). Also added synchronous convenience method `run_sync`. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR6-R24) [[2]](diffhunk://#diff-be02100d7c22f2ca79921dbd8ebae61bb0c0475af8123464dadc58ee88384cfaR1-R300) [[3]](diffhunk://#diff-a04128cf289c03a4c33221301d22624f3c09fa8220a123580cfb1f6deb5931efR4-R9) [[4]](diffhunk://#diff-a04128cf289c03a4c33221301d22624f3c09fa8220a123580cfb1f6deb5931efR46-R55) [[5]](diffhunk://#diff-a04128cf289c03a4c33221301d22624f3c09fa8220a123580cfb1f6deb5931efR67-R68) [[6]](diffhunk://#diff-ac80c567ed8af25b8114ebf71c570d0931039238d6bea941e00d6420ffa91ba1R16-R20) [[7]](diffhunk://#diff-ac80c567ed8af25b8114ebf71c570d0931039238d6bea941e00d6420ffa91ba1R72)
* Introduced capability management methods: `client.agents.providers(email)` to list available providers and `client.agents.set_provider(email, provider)` to set the default provider, with REST API integration. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR6-R24) [[2]](diffhunk://#diff-be02100d7c22f2ca79921dbd8ebae61bb0c0475af8123464dadc58ee88384cfaR1-R300)
* Added `Provider` enum for agent runtimes, with `OpenCode` as the default and `ClaudeCode` requiring capability gating. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR6-R24) [[2]](diffhunk://#diff-135ac383f316d935209a567bd0c60d5898b58a93fd8c9733950da67b2061f1a5R57-R63) [[3]](diffhunk://#diff-a04128cf289c03a4c33221301d22624f3c09fa8220a123580cfb1f6deb5931efR4-R9) [[4]](diffhunk://#diff-ac80c567ed8af25b8114ebf71c570d0931039238d6bea941e00d6420ffa91ba1R16-R20) [[5]](diffhunk://#diff-ac80c567ed8af25b8114ebf71c570d0931039238d6bea941e00d6420ffa91ba1R42)

Error handling and configuration:

* Introduced `ProviderUnavailableError` (raised if a provider is not available for the user) and `AgentRunError` (for mid-stream failures/timeouts). The agent runtime now keys identity and capability gating on user email (`config.user_email` or `MANTIS_USER_EMAIL`) instead of user ID. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR6-R24) [[2]](diffhunk://#diff-be02100d7c22f2ca79921dbd8ebae61bb0c0475af8123464dadc58ee88384cfaR1-R300) [[3]](diffhunk://#diff-a04128cf289c03a4c33221301d22624f3c09fa8220a123580cfb1f6deb5931efR4-R9) [[4]](diffhunk://#diff-a04128cf289c03a4c33221301d22624f3c09fa8220a123580cfb1f6deb5931efR18-R26) [[5]](diffhunk://#diff-a04128cf289c03a4c33221301d22624f3c09fa8220a123580cfb1f6deb5931efR67-R68) [[6]](diffhunk://#diff-4df7ca2f6e47f13c29784e193efca1574103ba9e1a339d0d08532ae70fec7750R33-R36)

Documentation and examples:

* Updated `README.md` with usage instructions and event types for the new agent runtime, including async and sync examples, provider management, and capability gating. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R71) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R99-R128)
* Added `examples/agent_run.py` demonstrating how to run an agent session, handle events, and manage provider capabilities.

Other:

* Bumped version to 0.12.0 and updated `CHANGELOG.md` to document the new features and breaking changes. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR6-R24) [[2]](diffhunk://#diff-a04128cf289c03a4c33221301d22624f3c09fa8220a123580cfb1f6deb5931efR18-R26)