### PR TITLE
Demo mantis on mantis

### DIFF
--- a/examples/repo_radar/README.md
+++ b/examples/repo_radar/README.md
@@ -1,0 +1,50 @@
+# Repo Radar — Mantis mapping Mantis
+
+A standing intelligence officer for the Mantis project itself. One headless, scriptable run
+that exercises most of the platform end-to-end — and does things the Mantis UI structurally
+cannot.
+
+## What it does (4 phases, each degrades gracefully)
+
+1. **Build a portfolio of maps** from the project's *own* data — open PRs + issues across
+   `KellisLab/MantisAPI` and `KellisLab/Mantis` (GitHub REST), a contributor rollup from local
+   git history, and the team's meeting-notes Google Doc. Each becomes a Mantis space via
+   `client.spaces.create(...)`.
+2. **Notebook delta analysis** — for each map, run Python *in the map's kernel* (`points` in
+   scope) to compute velocity/breakdowns, render a contributor chart, and `checkpoint()` so the
+   next run diffs week-over-week.
+3. **Agent synthesis** — a provider-scoped agent (`client.agents`, opencode default /
+   claude_code opt-in) reads the richest map and writes the briefing's analysis. Set
+   `REPO_RADAR_ALL_SPACES=1` to try the cross-map composer mode.
+4. **Briefing** — assemble `repo_radar_brief.md` (portfolio + deltas + synthesis + chart).
+
+## Why this can't be done in the Mantis UI
+- It spans **four maps at once** (the UI is single-space).
+- It **diffs against last week** via kernel checkpoints (no UI for that).
+- It's **headless + scriptable + schedulable** (no batch/automation UI) — drop it in cron for a
+  weekly briefing.
+
+## Run it
+
+```bash
+export GITHUB_TOKEN=...                      # to pull the private repos
+export MANTIS_BACKEND_HOST=http://localhost:8000
+export MANTIS_COOKIE='next-auth.session-token=...'   # or MANTIS_COOKIE_FILE=/path
+export MANTIS_USER_EMAIL=you@example.com     # the agent runtime keys on email
+export MANTISAPI_PATH=/path/to/MantisAPI     # local clone, for git author rollup
+export MANTIS_PROVIDER=claude_code           # or opencode (default)
+# optional: REPO_RADAR_CAP=20 (bounded run), REPO_RADAR_ALL_SPACES=1, REPO_RADAR_STATE=...
+
+python examples/repo_radar/repo_radar.py
+```
+
+By default it talks **straight to the backend** (`base_url=""`); set `MANTIS_BASE_URL=/api/proxy/`
+to route through the Next.js proxy instead.
+
+## Requirements / honest caveats
+- **Map creation** needs the synthesis celery worker; **notebooks** need the kernel docker stack;
+  **agents** need the runtime + a real model credential (Bedrock for `claude_code`, OpenAI for
+  `opencode`). Phases are independent — if one stack is down, the others still produce output and
+  the failure is reported in the brief, not fatal.
+- `sources.py` is plain ingestion (no SDK import) and can be run standalone to sanity-check the
+  pullers: `python examples/repo_radar/sources.py`.

--- a/examples/repo_radar/repo_radar.py
+++ b/examples/repo_radar/repo_radar.py
@@ -88,8 +88,8 @@ def build_maps(client: MantisClient) -> tuple[str, dict[str, str]]:
         "prs": lambda: sources.github_prs(),
         "issues": lambda: sources.github_issues(),
         "authors": lambda: sources.github_authors(),
-        "code": lambda: sources.github_code(),
         "notes": lambda: sources.meeting_notes(),
+        "code": lambda: sources.github_code(),  # largest — run last so others don't queue behind it
     }
     # friendly per-map titles (without this the backend names every map "Untitled Map").
     map_titles = {
@@ -114,6 +114,7 @@ def build_maps(client: MantisClient) -> tuple[str, dict[str, str]]:
                 space_id=space_id, map_id=map_id,  # same space + stable map id ⇒ idempotent refresh
                 map_name=map_titles[name],  # so the map isn't named "Untitled Map"
                 show_progress=False,
+                stall_timeout=1800.0,  # code map can take a while for large file sets
                 on_progress=lambda p, m, t, n=name: print(f"    {n}: {p:3d}% {m or ''}", end="\r"),
             )
             maps[name] = handle.map_id
@@ -175,7 +176,7 @@ def analyze(client: MantisClient, maps_by_name: dict[str, str], state: dict) -> 
             nb = client.notebooks.from_map(map_id, name=f"radar-{name}",
                                            user_id=os.getenv("MANTIS_USER_EMAIL"))
             cell = nb.add_cell(DELTA_CODE)
-            cell.execute(timeout=120)
+            cell.execute(timeout=300)
             text = cell.text
             pts = _grab_int(text, "POINTS")
             delta = pts - prev.get(name, {}).get("points", pts)
@@ -185,7 +186,7 @@ def analyze(client: MantisClient, maps_by_name: dict[str, str], state: dict) -> 
             # one chart from the authors map for the brief
             if name == "authors" and chart_png is None:
                 chart = nb.add_cell(CHART_CODE)
-                chart.execute(timeout=120)
+                chart.execute(timeout=300)
                 png = chart.image_png_bytes()
                 if png:
                     chart_png = "/tmp/repo_radar_contributors.png"
@@ -247,8 +248,8 @@ async def synthesize(client: MantisClient, space_id: str, provider: Provider) ->
                     print(f"\n  [agent run reported failure] {ev.text}", flush=True)
             print()
             return analyst.result().text or "".join(chunks) or "_(agent returned no text — check model credentials)_"
-    except MantisError as exc:
-        return f"_(agent synthesis unavailable: {exc})_"
+    except Exception as exc:
+        return f"_(agent synthesis unavailable: {type(exc).__name__}: {exc})_"
 
 
 # ----------------------------------------------------------------------------- phase 4: brief

--- a/examples/repo_radar/repo_radar.py
+++ b/examples/repo_radar/repo_radar.py
@@ -231,7 +231,7 @@ Using the PRs, issues, contributors, and codebase maps in this space, write a co
 2-4 bullet points on the biggest themes of merged or near-merge work this week. Name the PRs and who owns them.
 
 ## Who's doing what
-A short table or list: for each active contributor, what area they're focused on (1 line each, max 8 people).
+A short table or list: for each active contributor, what area of the codebase they've been touching recently (use the Codebase map's last_author and last_updated fields — NOT issues). 1 line each, max 8 people.
 
 ## Risks & blockers
 2-3 bullet points on concrete risks: stale PRs, security gaps, unreviewed dependencies, broken tests, or resource bottlenecks.

--- a/examples/repo_radar/repo_radar.py
+++ b/examples/repo_radar/repo_radar.py
@@ -34,6 +34,7 @@ sys.path.insert(0, str(Path(__file__).parent))
 import sources  # noqa: E402
 
 from mantis_sdk import ConfigurationManager, MantisClient, Provider  # noqa: E402
+from mantis_sdk.enums import SpacePrivacy  # noqa: E402
 from mantis_sdk.exceptions import MantisError  # noqa: E402
 
 STATE_FILE = Path(os.getenv("REPO_RADAR_STATE", "/tmp/repo_radar_state.json"))
@@ -113,6 +114,7 @@ def build_maps(client: MantisClient) -> tuple[str, dict[str, str]]:
                 f"Mantis Radar — {name}", df, data_types,
                 space_id=space_id, map_id=map_id,  # same space + stable map id ⇒ idempotent refresh
                 map_name=map_titles[name],  # so the map isn't named "Untitled Map"
+                privacy_level=SpacePrivacy.PUBLIC,
                 show_progress=False,
                 stall_timeout=1800.0,  # code map can take a while for large file sets
                 on_progress=lambda p, m, t, n=name: print(f"    {n}: {p:3d}% {m or ''}", end="\r"),

--- a/examples/repo_radar/repo_radar.py
+++ b/examples/repo_radar/repo_radar.py
@@ -138,7 +138,7 @@ DELTA_CODE_TEMPLATE = """\
 # delta + velocity analysis — find THIS map by id in the kernel's maps list
 import collections, json
 _target = '{map_id}'
-_m = next((m for m in maps if m.map_id == _target), None) or maps[0]
+_m = next((m for m in maps if str(m.map_id) == _target), None) or maps[0]
 pts = _m.points
 rows = [getattr(p, 'metadata', {{}}) or {{}} for p in pts]
 n = len(pts)
@@ -157,7 +157,7 @@ import matplotlib
 matplotlib.use("Agg")
 import matplotlib.pyplot as plt
 _target = '{map_id}'
-_m = next((m for m in maps if m.map_id == _target), None) or maps[0]
+_m = next((m for m in maps if str(m.map_id) == _target), None) or maps[0]
 rows = [getattr(p, 'metadata', {{}}) or {{}} for p in _m.points]
 c = collections.Counter(r.get('author', 'unknown') for r in rows).most_common(10)
 labels = [a for a, _ in c]; vals = [v for _, v in c]

--- a/examples/repo_radar/repo_radar.py
+++ b/examples/repo_radar/repo_radar.py
@@ -111,7 +111,7 @@ def build_maps(client: MantisClient) -> tuple[str, dict[str, str]]:
             )
             maps[name] = handle.map_id
             print(f"\n  [done] {name}: map {handle.map_id}")
-        except MantisError as exc:
+        except Exception as exc:  # noqa: BLE001 — one bad source must not abort the whole run
             print(f"  [fail] {name}: {exc}")
 
     # alias the space ONCE (on first creation). the backend fix makes re-set idempotent, but we

--- a/examples/repo_radar/repo_radar.py
+++ b/examples/repo_radar/repo_radar.py
@@ -1,0 +1,269 @@
+"""Repo Radar — Mantis mapping Mantis.
+
+A standing intelligence officer for the Mantis project itself: it builds a *portfolio* of maps
+from the project's own GitHub (KellisLab/MantisAPI + KellisLab/Mantis) and meeting notes, runs
+notebook delta analysis (what's new since last run), then turns a cross-space agent loose to
+synthesize "what moved, what's the risk, where do the notes and the code disagree" — and writes
+a weekly briefing.
+
+Why this can't be done in the Mantis UI:
+  - it spans FOUR maps at once (UI is single-space);
+  - it diffs against last week via kernel checkpoints (no UI for that);
+  - it's one headless, scheduled, scriptable run (no batch/automation UI).
+
+Phases are independent and degrade gracefully — if the kernel or agent stack is down, the
+earlier phases still produce maps + a partial brief, and the failure is reported, not fatal.
+
+Env:
+  MANTIS_HOST / MANTIS_BACKEND_HOST   (default localhost:3000 / :8000)
+  MANTIS_COOKIE                        session cookie
+  MANTIS_USER_EMAIL                    (for the agent runtime)
+  GITHUB_TOKEN                         to pull the private repos
+  MANTISAPI_PATH / MANTIS_PATH         local clones (for git author rollup)
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+import sources  # noqa: E402
+
+from mantis_sdk import ConfigurationManager, MantisClient, Provider  # noqa: E402
+from mantis_sdk.exceptions import MantisError  # noqa: E402
+
+STATE_FILE = Path(os.getenv("REPO_RADAR_STATE", "/tmp/repo_radar_state.json"))
+
+
+# ----------------------------------------------------------------------------- client
+def make_client() -> MantisClient:
+    # base_url defaults to "" (talk straight to the backend) — set MANTIS_BASE_URL=/api/proxy/
+    # to route through the Next.js proxy instead. host defaults to the backend for the same reason.
+    backend = os.getenv("MANTIS_BACKEND_HOST", "http://localhost:8000")
+    config = ConfigurationManager().update({
+        "host": os.getenv("MANTIS_HOST", backend),
+        "backend_host": backend,
+        "user_email": os.getenv("MANTIS_USER_EMAIL"),
+        "request_timeout": float(os.getenv("MANTIS_REQUEST_TIMEOUT", "60")),
+    })
+    cookie = os.environ.get("MANTIS_COOKIE")
+    if not cookie and (cp := os.getenv("MANTIS_COOKIE_FILE")):
+        cookie = Path(cp).read_text().strip()
+    return MantisClient(os.getenv("MANTIS_BASE_URL", ""), cookie=cookie, config=config)
+
+
+def _load_state() -> dict:
+    if STATE_FILE.exists():
+        return json.loads(STATE_FILE.read_text())
+    return {}
+
+
+def _save_state(state: dict) -> None:
+    STATE_FILE.write_text(json.dumps(state, indent=2))
+
+
+# ----------------------------------------------------------------------------- phase 1: maps
+def build_maps(client: MantisClient) -> dict[str, str]:
+    """create the portfolio of maps from the project's own data. returns {name: space_id}."""
+    print("\n=== PHASE 1: building the Mantis-on-Mantis map portfolio ===")
+    builders = {
+        "prs": lambda: sources.github_prs(),
+        "issues": lambda: sources.github_issues(),
+        "authors": lambda: sources.github_authors(os.getenv("MANTISAPI_PATH", ".")),
+        "notes": lambda: sources.meeting_notes(),
+    }
+    spaces: dict[str, str] = {}
+    for name, build in builders.items():
+        try:
+            df, data_types = build()
+            cap = int(os.getenv("REPO_RADAR_CAP", "0"))  # optional row cap for bounded/demo runs
+            if cap:
+                df = df.head(cap)
+            if df.empty:
+                print(f"  [skip] {name}: no rows")
+                continue
+            print(f"  [create] {name}: {len(df)} points → submitting...")
+            handle = client.spaces.create(
+                f"Mantis Radar — {name}", df, data_types,
+                show_progress=False,
+                on_progress=lambda p, m, t, n=name: print(f"    {n}: {p:3d}% {m or ''}", end="\r"),
+            )
+            spaces[name] = handle.space_id
+            print(f"\n  [done] {name}: space {handle.space_id} (map {handle.map_id})")
+        except MantisError as exc:
+            print(f"  [fail] {name}: {exc}")
+    return spaces
+
+
+# ----------------------------------------------------------- phase 2: notebook delta analysis
+DELTA_CODE = """
+# delta + velocity analysis over this map's points (runs inside the map's kernel)
+import collections, json
+pts = maps[0].points
+rows = [getattr(p, 'metadata', {}) or {} for p in pts]
+n = len(pts)
+
+# velocity by author and state, derived from the point metadata
+authors = collections.Counter(r.get('author', 'unknown') for r in rows)
+states  = collections.Counter(r.get('state', r.get('topic', 'n/a')) for r in rows)
+
+print("POINTS", n)
+print("TOP_AUTHORS", json.dumps(authors.most_common(8)))
+print("STATE_BREAKDOWN", json.dumps(dict(states)))
+"""
+
+CHART_CODE = """
+import collections
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+rows = [getattr(p, 'metadata', {}) or {} for p in maps[0].points]
+c = collections.Counter(r.get('author', 'unknown') for r in rows).most_common(10)
+labels = [a for a, _ in c]; vals = [v for _, v in c]
+plt.figure(figsize=(9, 4))
+plt.bar(labels, vals)
+plt.xticks(rotation=45, ha='right'); plt.ylabel('contributions'); plt.title('Top contributors')
+plt.tight_layout(); plt.show()
+"""
+
+
+def analyze(client: MantisClient, spaces: dict[str, str], state: dict) -> dict:
+    """run delta analysis in each map's kernel; checkpoint for week-over-week diffs."""
+    print("\n=== PHASE 2: notebook delta analysis (per-map kernel) ===")
+    prev = state.get("metrics", {})
+    metrics: dict = {}
+    chart_png = None
+    for name, space_id in spaces.items():
+        try:
+            maps = client.maps.list(space_id)
+            map_id = maps[0]["id"] if maps else space_id
+            nb = client.notebooks.from_map(map_id, name=f"radar-{name}",
+                                           user_id=os.getenv("MANTIS_USER_EMAIL"))
+            cell = nb.add_cell(DELTA_CODE)
+            cell.execute(timeout=120)
+            text = cell.text
+            pts = _grab_int(text, "POINTS")
+            delta = pts - prev.get(name, {}).get("points", pts)
+            metrics[name] = {"points": pts, "delta_since_last_run": delta, "raw": text[:800]}
+            print(f"  [{name}] points={pts}  Δ={delta:+d} since last run")
+
+            # one chart from the authors map for the brief
+            if name == "authors" and chart_png is None:
+                chart = nb.add_cell(CHART_CODE)
+                chart.execute(timeout=120)
+                png = chart.image_png_bytes()
+                if png:
+                    chart_png = "/tmp/repo_radar_contributors.png"
+                    Path(chart_png).write_bytes(png)
+                    print(f"  [chart] saved {chart_png} ({len(png)} bytes)")
+
+            nb.checkpoint(f"radar-{name}-{int(time.time())}")
+        except MantisError as exc:
+            print(f"  [fail] {name}: {exc}  (needs the notebook kernel stack)")
+    metrics["_chart"] = chart_png
+    return metrics
+
+
+def _grab_int(text: str, key: str) -> int:
+    for line in text.splitlines():
+        if line.startswith(key):
+            try:
+                return int(line.split()[1])
+            except (IndexError, ValueError):
+                return 0
+    return 0
+
+
+# ------------------------------------------------------------- phase 3: agent synthesis
+# A per-space agent run (the verified provider path). all_spaces composer mode also exists
+# (client.agents.session(all_spaces=True, ...)) for true cross-map reasoning, but its replies
+# are delivered over a channel-layer group broadcast that doesn't reach a headless socket on
+# every deployment — so the robust demo path runs an agent against the richest single map and
+# the cross-map synthesis is done from the per-map metrics. Flip USE_ALL_SPACES to try it.
+USE_ALL_SPACES = os.getenv("REPO_RADAR_ALL_SPACES") == "1"
+
+SYNTHESIS_PROMPT = (
+    "You are Repo Radar, an intelligence officer for the Mantis project. Looking at this map of "
+    "the project's pull requests, give a tight briefing: (1) the single biggest theme of work, "
+    "citing specific PRs; (2) one concrete risk or gap; (3) one recommended priority for next "
+    "week. Be concise and cite items by title."
+)
+
+
+async def synthesize(client: MantisClient, spaces: dict[str, str], provider: Provider) -> str:
+    """run an agent to synthesize a briefing. provider-scoped (opencode default, claude_code
+    opt-in). degrades to a clear note if the agent runtime/credentials are unavailable."""
+    print(f"\n=== PHASE 3: agent synthesis (provider={provider}, all_spaces={USE_ALL_SPACES}) ===")
+    email = os.environ["MANTIS_USER_EMAIL"]
+    # anchor on the PRs map (richest signal); None space_id when all_spaces.
+    space_id = None if USE_ALL_SPACES else spaces.get("prs") or next(iter(spaces.values()))
+    try:
+        async with client.agents.session(space_id, all_spaces=USE_ALL_SPACES, provider=provider,
+                                         user_email=email, timeout=90) as analyst:
+            chunks: list[str] = []
+            async for ev in analyst.ask(SYNTHESIS_PROMPT):
+                if ev.type == "text":
+                    chunks.append(ev.text)
+                    print(ev.text, end="", flush=True)
+                elif ev.type == "tool_use":
+                    print(f"\n  [agent → {ev.tool_name}]", flush=True)
+                elif ev.type == "fail":
+                    print(f"\n  [agent run reported failure] {ev.text}", flush=True)
+            print()
+            return analyst.result().text or "".join(chunks) or "_(agent returned no text — check model credentials)_"
+    except MantisError as exc:
+        return f"_(agent synthesis unavailable: {exc})_"
+
+
+# ----------------------------------------------------------------------------- phase 4: brief
+def write_brief(spaces: dict[str, str], metrics: dict, synthesis: str) -> str:
+    """assemble the weekly markdown briefing."""
+    lines = [
+        "# 🐜 Repo Radar — Weekly Mantis Briefing",
+        f"_generated {time.strftime('%Y-%m-%d %H:%M')}_\n",
+        "## Portfolio",
+    ]
+    for name, sid in spaces.items():
+        m = metrics.get(name, {})
+        d = m.get("delta_since_last_run", 0)
+        lines.append(f"- **{name}** — {m.get('points', '?')} points "
+                     f"({d:+d} since last run) · `{sid}`")
+    lines += ["", "## Cross-space synthesis", synthesis or "_n/a_"]
+    chart = metrics.get("_chart")
+    if chart:
+        lines += ["", f"![contributors]({chart})"]
+    brief = "\n".join(lines)
+    out = Path(os.getenv("REPO_RADAR_BRIEF", "/tmp/repo_radar_brief.md"))
+    out.write_text(brief)
+    print(f"\n=== BRIEF written → {out} ===")
+    return brief
+
+
+# ----------------------------------------------------------------------------- main
+async def main():
+    provider = Provider(os.getenv("MANTIS_PROVIDER", "opencode"))
+    client = make_client()
+    state = _load_state()
+
+    spaces = build_maps(client)
+    if not spaces:
+        print("no maps created — aborting.")
+        return
+    state["spaces"] = spaces
+
+    metrics = analyze(client, spaces, state)
+    state["metrics"] = {k: v for k, v in metrics.items() if not k.startswith("_")}
+
+    synthesis = await synthesize(client, spaces, provider)
+
+    brief = write_brief(spaces, metrics, synthesis)
+    _save_state(state)
+    print("\n" + "=" * 60 + "\n" + brief[:600])
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/repo_radar/repo_radar.py
+++ b/examples/repo_radar/repo_radar.py
@@ -28,6 +28,7 @@ import json
 import os
 import sys
 import time
+import uuid
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent))
@@ -67,36 +68,61 @@ def _save_state(state: dict) -> None:
 
 
 # ----------------------------------------------------------------------------- phase 1: maps
-def build_maps(client: MantisClient) -> dict[str, str]:
-    """create the portfolio of maps from the project's own data. returns {name: space_id}."""
-    print("\n=== PHASE 1: building the Mantis-on-Mantis map portfolio ===")
+ALIAS = os.getenv("REPO_RADAR_ALIAS", "m4m")
+
+
+def _stable_map_id(space_id: str, name: str) -> str:
+    """deterministic per-(space, logical map) id so re-runs refresh the SAME map in place."""
+    return str(uuid.uuid5(uuid.NAMESPACE_URL, f"{space_id}:{name}"))
+
+
+def build_maps(client: MantisClient) -> tuple[str, dict[str, str]]:
+    """idempotently maintain ONE aliased space (/space/<ALIAS>) holding the 4 radar maps.
+
+    re-runs reuse the same space (resolve via alias) and refresh each map in place via a stable
+    map_id — no duplicate spaces, no orphan maps. returns (space_id, {name: map_id})."""
+    print(f"\n=== PHASE 1: building the Mantis-on-Mantis space (/space/{ALIAS}) ===")
+    space_id, created = client.aliases.resolve_or_create_space(ALIAS)
+    print(f"  space {space_id} ({'new' if created else 'reused'})")
+
     builders = {
         "prs": lambda: sources.github_prs(),
         "issues": lambda: sources.github_issues(),
         "authors": lambda: sources.github_authors(os.getenv("MANTISAPI_PATH", ".")),
         "notes": lambda: sources.meeting_notes(),
     }
-    spaces: dict[str, str] = {}
+    maps: dict[str, str] = {}
+    cap = int(os.getenv("REPO_RADAR_CAP", "0"))  # optional row cap for bounded/demo runs
     for name, build in builders.items():
         try:
             df, data_types = build()
-            cap = int(os.getenv("REPO_RADAR_CAP", "0"))  # optional row cap for bounded/demo runs
             if cap:
                 df = df.head(cap)
             if df.empty:
                 print(f"  [skip] {name}: no rows")
                 continue
-            print(f"  [create] {name}: {len(df)} points → submitting...")
+            map_id = _stable_map_id(space_id, name)
+            print(f"  [upsert] {name}: {len(df)} points → map {map_id[:8]}…")
             handle = client.spaces.create(
                 f"Mantis Radar — {name}", df, data_types,
+                space_id=space_id, map_id=map_id,  # same space + stable map id ⇒ idempotent refresh
                 show_progress=False,
                 on_progress=lambda p, m, t, n=name: print(f"    {n}: {p:3d}% {m or ''}", end="\r"),
             )
-            spaces[name] = handle.space_id
-            print(f"\n  [done] {name}: space {handle.space_id} (map {handle.map_id})")
+            maps[name] = handle.map_id
+            print(f"\n  [done] {name}: map {handle.map_id}")
         except MantisError as exc:
             print(f"  [fail] {name}: {exc}")
-    return spaces
+
+    # alias the space ONCE (on first creation). the backend fix makes re-set idempotent, but we
+    # only need it on the first run; resolve_or_create told us whether this is that run.
+    if created and maps:
+        try:
+            client.aliases.set(space_id, ALIAS)
+            print(f"  [alias] /space/{ALIAS} → {space_id}")
+        except MantisError as exc:
+            print(f"  [alias fail] {exc}")
+    return space_id, maps
 
 
 # ----------------------------------------------------------- phase 2: notebook delta analysis
@@ -131,16 +157,14 @@ plt.tight_layout(); plt.show()
 """
 
 
-def analyze(client: MantisClient, spaces: dict[str, str], state: dict) -> dict:
+def analyze(client: MantisClient, maps_by_name: dict[str, str], state: dict) -> dict:
     """run delta analysis in each map's kernel; checkpoint for week-over-week diffs."""
     print("\n=== PHASE 2: notebook delta analysis (per-map kernel) ===")
     prev = state.get("metrics", {})
     metrics: dict = {}
     chart_png = None
-    for name, space_id in spaces.items():
+    for name, map_id in maps_by_name.items():
         try:
-            maps = client.maps.list(space_id)
-            map_id = maps[0]["id"] if maps else space_id
             nb = client.notebooks.from_map(map_id, name=f"radar-{name}",
                                            user_id=os.getenv("MANTIS_USER_EMAIL"))
             cell = nb.add_cell(DELTA_CODE)
@@ -194,15 +218,17 @@ SYNTHESIS_PROMPT = (
 )
 
 
-async def synthesize(client: MantisClient, spaces: dict[str, str], provider: Provider) -> str:
+async def synthesize(client: MantisClient, space_id: str, provider: Provider) -> str:
     """run an agent to synthesize a briefing. provider-scoped (opencode default, claude_code
-    opt-in). degrades to a clear note if the agent runtime/credentials are unavailable."""
+    opt-in). degrades to a clear note if the agent runtime/credentials are unavailable.
+
+    the agent is scoped to the one m4m space (it auto-mints a space-state so its MCP tools can
+    inspect the maps). all_spaces mode would reason across every accessible space instead."""
     print(f"\n=== PHASE 3: agent synthesis (provider={provider}, all_spaces={USE_ALL_SPACES}) ===")
     email = os.environ["MANTIS_USER_EMAIL"]
-    # anchor on the PRs map (richest signal); None space_id when all_spaces.
-    space_id = None if USE_ALL_SPACES else spaces.get("prs") or next(iter(spaces.values()))
+    target = None if USE_ALL_SPACES else space_id
     try:
-        async with client.agents.session(space_id, all_spaces=USE_ALL_SPACES, provider=provider,
+        async with client.agents.session(target, all_spaces=USE_ALL_SPACES, provider=provider,
                                          user_email=email, timeout=90) as analyst:
             chunks: list[str] = []
             async for ev in analyst.ask(SYNTHESIS_PROMPT):
@@ -220,19 +246,20 @@ async def synthesize(client: MantisClient, spaces: dict[str, str], provider: Pro
 
 
 # ----------------------------------------------------------------------------- phase 4: brief
-def write_brief(spaces: dict[str, str], metrics: dict, synthesis: str) -> str:
+def write_brief(space_id: str, maps_by_name: dict[str, str], metrics: dict, synthesis: str) -> str:
     """assemble the weekly markdown briefing."""
+    host = os.getenv("MANTIS_HOST", os.getenv("MANTIS_BACKEND_HOST", ""))
     lines = [
         "# 🐜 Repo Radar — Weekly Mantis Briefing",
         f"_generated {time.strftime('%Y-%m-%d %H:%M')}_\n",
-        "## Portfolio",
+        f"**Space:** [/space/{ALIAS}]({host}/space/{ALIAS}) · `{space_id}`\n",
+        "## Maps",
     ]
-    for name, sid in spaces.items():
+    for name in maps_by_name:
         m = metrics.get(name, {})
         d = m.get("delta_since_last_run", 0)
-        lines.append(f"- **{name}** — {m.get('points', '?')} points "
-                     f"({d:+d} since last run) · `{sid}`")
-    lines += ["", "## Cross-space synthesis", synthesis or "_n/a_"]
+        lines.append(f"- **{name}** — {m.get('points', '?')} points ({d:+d} since last run)")
+    lines += ["", "## Synthesis", synthesis or "_n/a_"]
     chart = metrics.get("_chart")
     if chart:
         lines += ["", f"![contributors]({chart})"]
@@ -249,18 +276,19 @@ async def main():
     client = make_client()
     state = _load_state()
 
-    spaces = build_maps(client)
-    if not spaces:
+    space_id, maps_by_name = build_maps(client)
+    if not maps_by_name:
         print("no maps created — aborting.")
         return
-    state["spaces"] = spaces
+    state["space_id"] = space_id
+    state["maps"] = maps_by_name
 
-    metrics = analyze(client, spaces, state)
+    metrics = analyze(client, maps_by_name, state)
     state["metrics"] = {k: v for k, v in metrics.items() if not k.startswith("_")}
 
-    synthesis = await synthesize(client, spaces, provider)
+    synthesis = await synthesize(client, space_id, provider)
 
-    brief = write_brief(spaces, metrics, synthesis)
+    brief = write_brief(space_id, maps_by_name, metrics, synthesis)
     _save_state(state)
     print("\n" + "=" * 60 + "\n" + brief[:600])
 

--- a/examples/repo_radar/repo_radar.py
+++ b/examples/repo_radar/repo_radar.py
@@ -228,9 +228,11 @@ SYNTHESIS_PROMPT = (
 )
 
 
-async def synthesize(client: MantisClient, space_id: str, provider: Provider) -> str:
-    """run an agent to synthesize a briefing. provider-scoped (opencode default, claude_code
-    opt-in). degrades to a clear note if the agent runtime/credentials are unavailable.
+async def synthesize(client: MantisClient, space_id: str, provider: Provider) -> tuple[str, str | None]:
+    """run an agent to synthesize a briefing. returns (text, chat_id).
+
+    provider-scoped (opencode default, claude_code opt-in). degrades gracefully if the agent
+    runtime/credentials are unavailable.
 
     the agent is scoped to the one m4m space (it auto-mints a space-state so its MCP tools can
     inspect the maps). all_spaces mode would reason across every accessible space instead."""
@@ -250,9 +252,10 @@ async def synthesize(client: MantisClient, space_id: str, provider: Provider) ->
                 elif ev.type == "fail":
                     print(f"\n  [agent run reported failure] {ev.text}", flush=True)
             print()
-            return analyst.result().text or "".join(chunks) or "_(agent returned no text — check model credentials)_"
+            text = analyst.result().text or "".join(chunks) or "_(agent returned no text — check model credentials)_"
+            return text, analyst.chat_id
     except Exception as exc:
-        return f"_(agent synthesis unavailable: {type(exc).__name__}: {exc})_"
+        return f"_(agent synthesis unavailable: {type(exc).__name__}: {exc})_", None
 
 
 # ----------------------------------------------------------------------------- phase 4: brief
@@ -296,7 +299,15 @@ async def main():
     metrics = analyze(client, maps_by_name, state)
     state["metrics"] = {k: v for k, v in metrics.items() if not k.startswith("_")}
 
-    synthesis = await synthesize(client, space_id, provider)
+    synthesis, chat_id = await synthesize(client, space_id, provider)
+
+    # pin the synthesis conversation so visitors see it by default
+    if chat_id:
+        try:
+            client.featured_chat.set(space_id, chat_id)
+            print(f"  [featured] pinned chat {chat_id} to space")
+        except Exception as exc:
+            print(f"  [featured] failed to pin: {exc}")
 
     brief = write_brief(space_id, maps_by_name, metrics, synthesis)
     _save_state(state)

--- a/examples/repo_radar/repo_radar.py
+++ b/examples/repo_radar/repo_radar.py
@@ -174,7 +174,9 @@ def analyze(client: MantisClient, maps_by_name: dict[str, str], state: dict) -> 
     prev = state.get("metrics", {})
     metrics: dict = {}
     chart_png = None
-    for name, map_id in maps_by_name.items():
+    # skip code map — it rebuilds last and the kernel loads stale (0-point) data during rebuild
+    notebook_maps = {k: v for k, v in maps_by_name.items() if k != "code"}
+    for name, map_id in notebook_maps.items():
         try:
             nb = client.notebooks.from_map(map_id, name=f"radar-{name}",
                                            user_id=os.getenv("MANTIS_USER_EMAIL"))
@@ -220,12 +222,25 @@ def _grab_int(text: str, key: str) -> int:
 # the cross-map synthesis is done from the per-map metrics. Flip USE_ALL_SPACES to try it.
 USE_ALL_SPACES = os.getenv("REPO_RADAR_ALL_SPACES") == "1"
 
-SYNTHESIS_PROMPT = (
-    "You are Repo Radar, an intelligence officer for the Mantis project. Looking at this map of "
-    "the project's pull requests, give a tight briefing: (1) the single biggest theme of work, "
-    "citing specific PRs; (2) one concrete risk or gap; (3) one recommended priority for next "
-    "week. Be concise and cite items by title."
-)
+SYNTHESIS_PROMPT = """\
+You are Repo Radar, a weekly intelligence digest for the Mantis engineering team.
+
+Using the PRs, issues, contributors, and codebase maps in this space, write a concise team-readable briefing. Format it exactly like this:
+
+## What shipped / is shipping
+2-4 bullet points on the biggest themes of merged or near-merge work this week. Name the PRs and who owns them.
+
+## Who's doing what
+A short table or list: for each active contributor, what area they're focused on (1 line each, max 8 people).
+
+## Risks & blockers
+2-3 bullet points on concrete risks: stale PRs, security gaps, unreviewed dependencies, broken tests, or resource bottlenecks.
+
+## Recommended priorities (next week)
+2-3 actionable bullets the team lead can act on Monday morning.
+
+Keep it scannable — short sentences, bold the PR titles, use people's GitHub handles. No preamble, no sign-off.\
+"""
 
 
 async def synthesize(client: MantisClient, space_id: str, provider: Provider) -> tuple[str, str | None]:

--- a/examples/repo_radar/repo_radar.py
+++ b/examples/repo_radar/repo_radar.py
@@ -253,9 +253,14 @@ async def synthesize(client: MantisClient, space_id: str, provider: Provider) ->
                     print(f"\n  [agent run reported failure] {ev.text}", flush=True)
             print()
             text = analyst.result().text or "".join(chunks) or "_(agent returned no text — check model credentials)_"
-            return text, analyst.server_chat_id or analyst.chat_id
+            # build message list for persistence
+            messages = [
+                {"role": "user", "content": SYNTHESIS_PROMPT},
+                {"role": "assistant", "content": text},
+            ]
+            return text, analyst.server_chat_id or analyst.chat_id, messages
     except Exception as exc:
-        return f"_(agent synthesis unavailable: {type(exc).__name__}: {exc})_", None
+        return f"_(agent synthesis unavailable: {type(exc).__name__}: {exc})_", None, None
 
 
 # ----------------------------------------------------------------------------- phase 4: brief
@@ -299,12 +304,13 @@ async def main():
     metrics = analyze(client, maps_by_name, state)
     state["metrics"] = {k: v for k, v in metrics.items() if not k.startswith("_")}
 
-    synthesis, chat_id = await synthesize(client, space_id, provider)
+    synthesis, chat_id, chat_messages = await synthesize(client, space_id, provider)
 
     # pin the synthesis conversation so visitors see it by default
     if chat_id:
         try:
-            client.featured_chat.set(space_id, chat_id)
+            client.featured_chat.set(space_id, chat_id, messages=chat_messages,
+                                     title="Repo Radar Briefing")
             print(f"  [featured] pinned chat {chat_id} to space")
         except Exception as exc:
             print(f"  [featured] failed to pin: {exc}")

--- a/examples/repo_radar/repo_radar.py
+++ b/examples/repo_radar/repo_radar.py
@@ -134,14 +134,15 @@ def build_maps(client: MantisClient) -> tuple[str, dict[str, str]]:
 
 
 # ----------------------------------------------------------- phase 2: notebook delta analysis
-DELTA_CODE = """
-# delta + velocity analysis over this map's points (runs inside the map's kernel)
+DELTA_CODE_TEMPLATE = """\
+# delta + velocity analysis — find THIS map by id in the kernel's maps list
 import collections, json
-pts = maps[0].points
-rows = [getattr(p, 'metadata', {}) or {} for p in pts]
+_target = '{map_id}'
+_m = next((m for m in maps if m.map_id == _target), None) or maps[0]
+pts = _m.points
+rows = [getattr(p, 'metadata', {{}}) or {{}} for p in pts]
 n = len(pts)
 
-# velocity by author and state, derived from the point metadata
 authors = collections.Counter(r.get('author', 'unknown') for r in rows)
 states  = collections.Counter(r.get('state', r.get('topic', 'n/a')) for r in rows)
 
@@ -150,12 +151,14 @@ print("TOP_AUTHORS", json.dumps(authors.most_common(8)))
 print("STATE_BREAKDOWN", json.dumps(dict(states)))
 """
 
-CHART_CODE = """
+CHART_CODE_TEMPLATE = """\
 import collections
 import matplotlib
 matplotlib.use("Agg")
 import matplotlib.pyplot as plt
-rows = [getattr(p, 'metadata', {}) or {} for p in maps[0].points]
+_target = '{map_id}'
+_m = next((m for m in maps if m.map_id == _target), None) or maps[0]
+rows = [getattr(p, 'metadata', {{}}) or {{}} for p in _m.points]
 c = collections.Counter(r.get('author', 'unknown') for r in rows).most_common(10)
 labels = [a for a, _ in c]; vals = [v for _, v in c]
 plt.figure(figsize=(9, 4))
@@ -175,7 +178,7 @@ def analyze(client: MantisClient, maps_by_name: dict[str, str], state: dict) -> 
         try:
             nb = client.notebooks.from_map(map_id, name=f"radar-{name}",
                                            user_id=os.getenv("MANTIS_USER_EMAIL"))
-            cell = nb.add_cell(DELTA_CODE)
+            cell = nb.add_cell(DELTA_CODE_TEMPLATE.format(map_id=map_id))
             cell.execute(timeout=300)
             text = cell.text
             pts = _grab_int(text, "POINTS")
@@ -185,7 +188,7 @@ def analyze(client: MantisClient, maps_by_name: dict[str, str], state: dict) -> 
 
             # one chart from the authors map for the brief
             if name == "authors" and chart_png is None:
-                chart = nb.add_cell(CHART_CODE)
+                chart = nb.add_cell(CHART_CODE_TEMPLATE.format(map_id=map_id))
                 chart.execute(timeout=300)
                 png = chart.image_png_bytes()
                 if png:

--- a/examples/repo_radar/repo_radar.py
+++ b/examples/repo_radar/repo_radar.py
@@ -253,7 +253,7 @@ async def synthesize(client: MantisClient, space_id: str, provider: Provider) ->
                     print(f"\n  [agent run reported failure] {ev.text}", flush=True)
             print()
             text = analyst.result().text or "".join(chunks) or "_(agent returned no text — check model credentials)_"
-            return text, analyst.chat_id
+            return text, analyst.server_chat_id or analyst.chat_id
     except Exception as exc:
         return f"_(agent synthesis unavailable: {type(exc).__name__}: {exc})_", None
 

--- a/examples/repo_radar/repo_radar.py
+++ b/examples/repo_radar/repo_radar.py
@@ -88,12 +88,14 @@ def build_maps(client: MantisClient) -> tuple[str, dict[str, str]]:
         "prs": lambda: sources.github_prs(),
         "issues": lambda: sources.github_issues(),
         "authors": lambda: sources.github_authors(),
+        "code": lambda: sources.github_code(),
         "notes": lambda: sources.meeting_notes(),
     }
     # friendly per-map titles (without this the backend names every map "Untitled Map").
     map_titles = {
         "prs": "Open Pull Requests", "issues": "Open Issues",
-        "authors": "Contributors (all-time)", "notes": "Meeting Notes",
+        "authors": "Contributors (all-time)", "code": "Codebase",
+        "notes": "Meeting Notes",
     }
     maps: dict[str, str] = {}
     cap = int(os.getenv("REPO_RADAR_CAP", "0"))  # optional row cap for bounded/demo runs
@@ -190,7 +192,6 @@ def analyze(client: MantisClient, maps_by_name: dict[str, str], state: dict) -> 
                     Path(chart_png).write_bytes(png)
                     print(f"  [chart] saved {chart_png} ({len(png)} bytes)")
 
-            nb.checkpoint(f"radar-{name}-{int(time.time())}")
         except MantisError as exc:
             print(f"  [fail] {name}: {exc}  (needs the notebook kernel stack)")
     metrics["_chart"] = chart_png

--- a/examples/repo_radar/repo_radar.py
+++ b/examples/repo_radar/repo_radar.py
@@ -18,8 +18,7 @@ Env:
   MANTIS_HOST / MANTIS_BACKEND_HOST   (default localhost:3000 / :8000)
   MANTIS_COOKIE                        session cookie
   MANTIS_USER_EMAIL                    (for the agent runtime)
-  GITHUB_TOKEN                         to pull the private repos
-  MANTISAPI_PATH / MANTIS_PATH         local clones (for git author rollup)
+  GITHUB_TOKEN                         to pull the private repos (PRs, issues, authors)
 """
 from __future__ import annotations
 
@@ -88,8 +87,13 @@ def build_maps(client: MantisClient) -> tuple[str, dict[str, str]]:
     builders = {
         "prs": lambda: sources.github_prs(),
         "issues": lambda: sources.github_issues(),
-        "authors": lambda: sources.github_authors(os.getenv("MANTISAPI_PATH", ".")),
+        "authors": lambda: sources.github_authors(),
         "notes": lambda: sources.meeting_notes(),
+    }
+    # friendly per-map titles (without this the backend names every map "Untitled Map").
+    map_titles = {
+        "prs": "Open Pull Requests", "issues": "Open Issues",
+        "authors": "Contributors (all-time)", "notes": "Meeting Notes",
     }
     maps: dict[str, str] = {}
     cap = int(os.getenv("REPO_RADAR_CAP", "0"))  # optional row cap for bounded/demo runs
@@ -106,6 +110,7 @@ def build_maps(client: MantisClient) -> tuple[str, dict[str, str]]:
             handle = client.spaces.create(
                 f"Mantis Radar — {name}", df, data_types,
                 space_id=space_id, map_id=map_id,  # same space + stable map id ⇒ idempotent refresh
+                map_name=map_titles[name],  # so the map isn't named "Untitled Map"
                 show_progress=False,
                 on_progress=lambda p, m, t, n=name: print(f"    {n}: {p:3d}% {m or ''}", end="\r"),
             )

--- a/examples/repo_radar/sources.py
+++ b/examples/repo_radar/sources.py
@@ -209,6 +209,69 @@ def meeting_notes(gdoc_id: str = GDOC_ID) -> tuple[pd.DataFrame, dict]:
     return df, types
 
 
+# ----------------------------------------------------------------------------- code files
+_CODE_EXTENSIONS = {
+    ".py", ".ts", ".tsx", ".js", ".jsx", ".yml", ".yaml", ".toml",
+    ".sh", ".sql", ".html", ".css", ".scss", ".json", ".md",
+    ".dockerfile", ".cfg", ".ini", ".env.example",
+}
+_SKIP_DIRS = {"node_modules", "__pycache__", ".git", "venv", "dist", "build", ".next", "migrations"}
+_MAX_SNIPPET = 1500  # chars of file content to embed (keeps token cost bounded)
+
+
+def github_code(repos: list[str] = REPOS, branch: str = "main") -> tuple[pd.DataFrame, dict]:
+    """Source-tree walk of both repos via the Git Trees API — one point per file.
+
+    Each file becomes a point whose semantic content is the first ~1500 chars of its source
+    (enough for the imports/docstring/class signature), and whose facets capture the path
+    structure so you can explore by directory, extension, and repo."""
+    rows = []
+    for repo in repos:
+        tree_url = f"{_API}/repos/{repo}/git/trees/{branch}?recursive=1"
+        resp = requests.get(tree_url, headers=_gh_headers(), timeout=30)
+        resp.raise_for_status()
+        tree = resp.json().get("tree", [])
+
+        for entry in tree:
+            if entry.get("type") != "blob":
+                continue
+            path = entry["path"]
+            parts = path.split("/")
+            if any(d in _SKIP_DIRS for d in parts[:-1]):
+                continue
+            ext = os.path.splitext(path)[1].lower()
+            # include Dockerfiles (no extension match but filename starts with Dockerfile)
+            basename = parts[-1].lower()
+            if ext not in _CODE_EXTENSIONS and not basename.startswith("dockerfile"):
+                continue
+
+            # fetch raw content (bounded by _MAX_SNIPPET)
+            raw_url = f"https://raw.githubusercontent.com/{repo}/{branch}/{path}"
+            try:
+                raw_resp = requests.get(raw_url, headers=_gh_headers(), timeout=10)
+                raw_resp.raise_for_status()
+                snippet = raw_resp.text[:_MAX_SNIPPET]
+            except Exception:
+                snippet = f"(file at {path})"
+            time.sleep(0.05)  # stay well under rate limits
+
+            directory = "/".join(parts[:-1]) or "."
+            rows.append({
+                "title": path,
+                "content": snippet,
+                "repo": repo.split("/")[-1],
+                "directory": directory,
+                "extension": ext or basename,
+                "size": entry.get("size", 0),
+            })
+    df = pd.DataFrame(rows)
+    types = {
+        "title": "title", "content": "semantic", "repo": "categoric",
+        "directory": "categoric", "extension": "categoric", "size": "numeric",
+    }
+    return df, types
+
+
 if __name__ == "__main__":
     # standalone smoke: print row counts for each source (proves the pullers work).
     nb, _ = meeting_notes()
@@ -217,7 +280,8 @@ if __name__ == "__main__":
         prs, _ = github_prs()
         iss, _ = github_issues()
         auth, _ = github_authors()
+        code, _ = github_code()
         print(f"github_prs(open): {len(prs)} | github_issues(open): {len(iss)} | "
-              f"authors(all-time): {len(auth)}")
+              f"authors(all-time): {len(auth)} | code(files): {len(code)}")
     else:
         print("set GITHUB_TOKEN to smoke-test the github pullers")

--- a/examples/repo_radar/sources.py
+++ b/examples/repo_radar/sources.py
@@ -219,12 +219,64 @@ _MAX_SNIPPET = 1200  # chars of file content to embed
 _MAX_FILES = 800  # cap total files to keep embedding time reasonable
 
 
+def _build_file_commit_stats(repos: list[str], max_commits: int = 50) -> dict[str, dict]:
+    """Build per-file stats (top_author, last_author, last_updated) from recent commit details.
+
+    Fetches the last `max_commits` commits per repo with their file lists (one API call each)
+    to build author/date metadata per file path."""
+    from collections import Counter
+    file_authors: dict[str, list[str]] = {}
+    file_dates: dict[str, str] = {}
+
+    for repo in repos:
+        repo_short = repo.split("/")[-1]
+        # get recent commit SHAs
+        commits = _paginate(f"{_API}/repos/{repo}/commits", {}, max_pages=1)[:max_commits]
+        for commit in commits:
+            sha = commit.get("sha")
+            login = (commit.get("author") or {}).get("login") or "unknown"
+            date = (commit.get("commit", {}).get("author", {}).get("date") or "")[:10]
+            if not sha:
+                continue
+            # fetch detail to get files list
+            try:
+                detail = requests.get(
+                    f"{_API}/repos/{repo}/commits/{sha}",
+                    headers=_gh_headers(), timeout=15,
+                ).json()
+            except Exception:
+                continue
+            for f in detail.get("files", []):
+                path = f.get("filename", "")
+                if not path:
+                    continue
+                key = f"{repo_short}/{path}"
+                file_authors.setdefault(key, []).append(login)
+                if date and (not file_dates.get(key) or date > file_dates[key]):
+                    file_dates[key] = date
+            time.sleep(0.05)
+
+    stats = {}
+    for key, authors in file_authors.items():
+        c = Counter(authors)
+        stats[key] = {
+            "top_author": c.most_common(1)[0][0],
+            "last_author": authors[0],
+            "last_updated": file_dates.get(key, ""),
+        }
+    return stats
+
+
 def github_code(repos: list[str] = REPOS, branch: str = "main") -> tuple[pd.DataFrame, dict]:
     """Source-tree walk of both repos via the Git Trees API — one point per source file.
 
     Focuses on Python/TS/JS source files (not configs), sorted by size descending and capped
     at _MAX_FILES to keep embedding time under ~10 minutes. Each point's semantic content is
-    the first ~1200 chars (imports + top-level signatures)."""
+    the first ~1200 chars (imports + top-level signatures). Enriched with commit metadata
+    (most frequent author, last author, last updated date)."""
+    # pre-fetch commit stats for author/date enrichment
+    file_stats = _build_file_commit_stats(repos)
+
     candidates = []
     for repo in repos:
         tree_url = f"{_API}/repos/{repo}/git/trees/{branch}?recursive=1"
@@ -264,18 +316,24 @@ def github_code(repos: list[str] = REPOS, branch: str = "main") -> tuple[pd.Data
         time.sleep(0.02)
 
         directory = "/".join(parts[:-1]) or "."
+        repo_short = repo.split("/")[-1]
+        stats = file_stats.get(f"{repo_short}/{path}", {})
         rows.append({
             "title": path,
             "content": snippet,
-            "repo": repo.split("/")[-1],
+            "repo": repo_short,
             "directory": directory,
             "extension": ext,
             "size": size,
+            "top_author": stats.get("top_author", "unknown"),
+            "last_author": stats.get("last_author", "unknown"),
+            "last_updated": stats.get("last_updated", ""),
         })
     df = pd.DataFrame(rows)
     types = {
         "title": "title", "content": "semantic", "repo": "categoric",
         "directory": "categoric", "extension": "categoric", "size": "numeric",
+        "top_author": "categoric", "last_author": "categoric", "last_updated": "date",
     }
     return df, types
 

--- a/examples/repo_radar/sources.py
+++ b/examples/repo_radar/sources.py
@@ -105,12 +105,25 @@ def github_issues(repos: list[str] = REPOS, state: str = "all") -> tuple[pd.Data
 # ------------------------------------------------------------------------- git author rollup
 def github_authors(repo_path: str, since_days: int = 90) -> tuple[pd.DataFrame, dict]:
     """per-author contribution rollup from the LOCAL git clone (no API needed).
-    one point per author; commit count is numeric so the map can size/color by activity."""
+    one point per author; commit count is numeric so the map can size/color by activity.
+
+    raises ValueError (not CalledProcessError) if repo_path isn't a git repo, so the caller's
+    'one source failed, skip it' handling kicks in cleanly."""
+    import os.path
+
     fmt = "%an\t%s"
-    out = subprocess.run(
+    if not os.path.isdir(os.path.join(repo_path, ".git")):
+        raise ValueError(
+            f"MANTISAPI_PATH={repo_path!r} is not a git checkout — set it to your local "
+            f"MantisAPI clone (e.g. ~/Mantis/MantisAPI)."
+        )
+    proc = subprocess.run(
         ["git", "-C", repo_path, "log", f"--since={since_days} days ago", f"--format={fmt}"],
-        capture_output=True, text=True, check=True,
-    ).stdout.strip().splitlines()
+        capture_output=True, text=True, check=False,
+    )
+    if proc.returncode != 0:
+        raise ValueError(f"git log failed in {repo_path!r}: {proc.stderr.strip()[:200]}")
+    out = proc.stdout.strip().splitlines()
 
     agg: dict[str, dict] = {}
     for line in out:

--- a/examples/repo_radar/sources.py
+++ b/examples/repo_radar/sources.py
@@ -210,22 +210,22 @@ def meeting_notes(gdoc_id: str = GDOC_ID) -> tuple[pd.DataFrame, dict]:
 
 
 # ----------------------------------------------------------------------------- code files
-_CODE_EXTENSIONS = {
-    ".py", ".ts", ".tsx", ".js", ".jsx", ".yml", ".yaml", ".toml",
-    ".sh", ".sql", ".html", ".css", ".scss", ".json", ".md",
-    ".dockerfile", ".cfg", ".ini", ".env.example",
+_CODE_EXTENSIONS = {".py", ".ts", ".tsx", ".js", ".jsx"}
+_SKIP_DIRS = {
+    "node_modules", "__pycache__", ".git", "venv", "dist", "build", ".next",
+    "migrations", "tests", "test", "__tests__", "fixtures", ".pytest_cache",
 }
-_SKIP_DIRS = {"node_modules", "__pycache__", ".git", "venv", "dist", "build", ".next", "migrations"}
-_MAX_SNIPPET = 1500  # chars of file content to embed (keeps token cost bounded)
+_MAX_SNIPPET = 1200  # chars of file content to embed
+_MAX_FILES = 800  # cap total files to keep embedding time reasonable
 
 
 def github_code(repos: list[str] = REPOS, branch: str = "main") -> tuple[pd.DataFrame, dict]:
-    """Source-tree walk of both repos via the Git Trees API — one point per file.
+    """Source-tree walk of both repos via the Git Trees API — one point per source file.
 
-    Each file becomes a point whose semantic content is the first ~1500 chars of its source
-    (enough for the imports/docstring/class signature), and whose facets capture the path
-    structure so you can explore by directory, extension, and repo."""
-    rows = []
+    Focuses on Python/TS/JS source files (not configs), sorted by size descending and capped
+    at _MAX_FILES to keep embedding time under ~10 minutes. Each point's semantic content is
+    the first ~1200 chars (imports + top-level signatures)."""
+    candidates = []
     for repo in repos:
         tree_url = f"{_API}/repos/{repo}/git/trees/{branch}?recursive=1"
         resp = requests.get(tree_url, headers=_gh_headers(), timeout=30)
@@ -240,30 +240,38 @@ def github_code(repos: list[str] = REPOS, branch: str = "main") -> tuple[pd.Data
             if any(d in _SKIP_DIRS for d in parts[:-1]):
                 continue
             ext = os.path.splitext(path)[1].lower()
-            # include Dockerfiles (no extension match but filename starts with Dockerfile)
-            basename = parts[-1].lower()
-            if ext not in _CODE_EXTENSIONS and not basename.startswith("dockerfile"):
+            if ext not in _CODE_EXTENSIONS:
                 continue
+            # skip test files by name
+            basename = parts[-1].lower()
+            if basename.startswith("test_") or basename.endswith("_test.py") or basename.endswith(".test.ts") or basename.endswith(".test.tsx"):
+                continue
+            candidates.append((repo, path, parts, ext, entry.get("size", 0)))
 
-            # fetch raw content (bounded by _MAX_SNIPPET)
-            raw_url = f"https://raw.githubusercontent.com/{repo}/{branch}/{path}"
-            try:
-                raw_resp = requests.get(raw_url, headers=_gh_headers(), timeout=10)
-                raw_resp.raise_for_status()
-                snippet = raw_resp.text[:_MAX_SNIPPET]
-            except Exception:
-                snippet = f"(file at {path})"
-            time.sleep(0.05)  # stay well under rate limits
+    # prioritize larger files (more substance) and cap
+    candidates.sort(key=lambda c: c[4], reverse=True)
+    candidates = candidates[:_MAX_FILES]
 
-            directory = "/".join(parts[:-1]) or "."
-            rows.append({
-                "title": path,
-                "content": snippet,
-                "repo": repo.split("/")[-1],
-                "directory": directory,
-                "extension": ext or basename,
-                "size": entry.get("size", 0),
-            })
+    rows = []
+    for repo, path, parts, ext, size in candidates:
+        raw_url = f"https://raw.githubusercontent.com/{repo}/{branch}/{path}"
+        try:
+            raw_resp = requests.get(raw_url, headers=_gh_headers(), timeout=10)
+            raw_resp.raise_for_status()
+            snippet = raw_resp.text[:_MAX_SNIPPET]
+        except Exception:
+            snippet = f"(file at {path})"
+        time.sleep(0.02)
+
+        directory = "/".join(parts[:-1]) or "."
+        rows.append({
+            "title": path,
+            "content": snippet,
+            "repo": repo.split("/")[-1],
+            "directory": directory,
+            "extension": ext,
+            "size": size,
+        })
     df = pd.DataFrame(rows)
     types = {
         "title": "title", "content": "semantic", "repo": "categoric",

--- a/examples/repo_radar/sources.py
+++ b/examples/repo_radar/sources.py
@@ -1,0 +1,181 @@
+"""data sources for the Mantis-on-Mantis demo (repo_radar).
+
+pulls four real corpora into pandas DataFrames ready for client.spaces.create():
+  - github_prs / github_issues  : open + recent PRs/issues across both repos (GitHub REST)
+  - github_authors              : per-author contribution rollup from local git history
+  - meeting_notes               : the Mantis meeting-notes Google Doc, split into dated entries
+
+each returns (df, data_types) so the caller just hands it to the SDK. no SDK imports here —
+this is plain ingestion so it can be tested / run standalone."""
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import time
+from typing import Any
+
+import pandas as pd
+import requests
+
+REPOS = ["KellisLab/MantisAPI", "KellisLab/Mantis"]
+GDOC_ID = "1phoQhus36Dc3SEsFCE4V18YDjxEadwXekn-VCZu0d3o"
+_API = "https://api.github.com"
+
+
+def _gh_headers() -> dict[str, str]:
+    tok = os.environ.get("GITHUB_TOKEN", "")
+    if not tok:
+        raise RuntimeError("set GITHUB_TOKEN to pull issues/PRs from the private repos")
+    return {"Authorization": f"token {tok}", "Accept": "application/vnd.github+json"}
+
+
+def _paginate(url: str, params: dict[str, Any], max_pages: int = 5) -> list[dict]:
+    """page through a GitHub list endpoint (capped, with a friendly log)."""
+    out: list[dict] = []
+    for page in range(1, max_pages + 1):
+        resp = requests.get(url, headers=_gh_headers(), params={**params, "page": page, "per_page": 100}, timeout=30)
+        resp.raise_for_status()
+        batch = resp.json()
+        if not batch:
+            break
+        out.extend(batch)
+        if len(batch) < 100:
+            break
+        time.sleep(0.2)  # be polite to the API
+    return out
+
+
+# ----------------------------------------------------------------------------- github PRs
+def github_prs(repos: list[str] = REPOS, state: str = "all") -> tuple[pd.DataFrame, dict]:
+    """open + recent PRs across the repos. title is semantic; state/repo/author categoric."""
+    rows = []
+    for repo in repos:
+        for pr in _paginate(f"{_API}/repos/{repo}/pulls", {"state": state, "sort": "updated"}):
+            body = (pr.get("body") or "").strip()
+            rows.append({
+                "title": f"#{pr['number']} {pr['title']}",
+                "summary": body[:2000],
+                "repo": repo.split("/")[-1],
+                "author": pr["user"]["login"] if pr.get("user") else "unknown",
+                "state": "merged" if pr.get("merged_at") else pr.get("state", "open"),
+                "draft": str(bool(pr.get("draft"))),
+                "labels": ", ".join(lbl["name"] for lbl in pr.get("labels", [])) or "none",
+                "created_at": (pr.get("created_at") or "")[:10],
+                "url": pr.get("html_url", ""),
+            })
+    df = pd.DataFrame(rows)
+    types = {
+        "title": "title", "summary": "semantic", "repo": "categoric", "author": "categoric",
+        "state": "categoric", "draft": "categoric", "labels": "categoric",
+        "created_at": "date", "url": "links",
+    }
+    return df, types
+
+
+# --------------------------------------------------------------------------- github issues
+def github_issues(repos: list[str] = REPOS, state: str = "all") -> tuple[pd.DataFrame, dict]:
+    """issues only (the issues endpoint returns PRs too; we filter them out)."""
+    rows = []
+    for repo in repos:
+        for it in _paginate(f"{_API}/repos/{repo}/issues", {"state": state, "sort": "updated"}):
+            if "pull_request" in it:  # the issues endpoint includes PRs — drop them
+                continue
+            body = (it.get("body") or "").strip()
+            rows.append({
+                "title": f"#{it['number']} {it['title']}",
+                "summary": body[:2000],
+                "repo": repo.split("/")[-1],
+                "author": it["user"]["login"] if it.get("user") else "unknown",
+                "state": it.get("state", "open"),
+                "labels": ", ".join(lbl["name"] for lbl in it.get("labels", [])) or "none",
+                "comments": it.get("comments", 0),
+                "created_at": (it.get("created_at") or "")[:10],
+                "url": it.get("html_url", ""),
+            })
+    df = pd.DataFrame(rows)
+    types = {
+        "title": "title", "summary": "semantic", "repo": "categoric", "author": "categoric",
+        "state": "categoric", "labels": "categoric", "comments": "numeric",
+        "created_at": "date", "url": "links",
+    }
+    return df, types
+
+
+# ------------------------------------------------------------------------- git author rollup
+def github_authors(repo_path: str, since_days: int = 90) -> tuple[pd.DataFrame, dict]:
+    """per-author contribution rollup from the LOCAL git clone (no API needed).
+    one point per author; commit count is numeric so the map can size/color by activity."""
+    fmt = "%an\t%s"
+    out = subprocess.run(
+        ["git", "-C", repo_path, "log", f"--since={since_days} days ago", f"--format={fmt}"],
+        capture_output=True, text=True, check=True,
+    ).stdout.strip().splitlines()
+
+    agg: dict[str, dict] = {}
+    for line in out:
+        if "\t" not in line:
+            continue
+        author, subject = line.split("\t", 1)
+        a = agg.setdefault(author, {"commits": 0, "subjects": []})
+        a["commits"] += 1
+        a["subjects"].append(subject)
+
+    rows = [
+        {
+            "title": author,
+            "summary": " • ".join(d["subjects"][:40]),  # what they actually worked on
+            "commits": d["commits"],
+            "author": author,
+        }
+        for author, d in agg.items()
+    ]
+    df = pd.DataFrame(rows).sort_values("commits", ascending=False) if rows else pd.DataFrame(rows)
+    types = {"title": "title", "summary": "semantic", "commits": "numeric", "author": "categoric"}
+    return df, types
+
+
+# ----------------------------------------------------------------------------- meeting notes
+def meeting_notes(gdoc_id: str = GDOC_ID) -> tuple[pd.DataFrame, dict]:
+    """the Mantis meeting-notes Google Doc, split into one point per dated meeting.
+
+    the doc uses headings like '2026.06.10 Wed5pm Mantis Leadership' — we split on those
+    and treat the body as the semantic field, the topic + date as facets."""
+    url = f"https://docs.google.com/document/d/{gdoc_id}/export?format=txt"
+    text = requests.get(url, timeout=30).text
+
+    # split on date-prefixed headings: 2026.06.10 ...
+    heading = re.compile(r"^(20\d\d\.\d\d\.\d\d)\s+(\w+)\s+(.*)$", re.MULTILINE)
+    matches = list(heading.finditer(text))
+    rows = []
+    for i, m in enumerate(matches):
+        start = m.end()
+        end = matches[i + 1].start() if i + 1 < len(matches) else len(text)
+        body = text[start:end].strip()
+        date_dot, topic = m.group(1), m.group(3).strip()  # group(2) is the weekday, unused
+        # topic looks like "Mantis Leadership" / "Mantis Agents Embeddings" — last word is a useful tag
+        tag = topic.replace("Mantis", "").strip().split()[0] if topic.replace("Mantis", "").strip() else "General"
+        rows.append({
+            "title": f"{date_dot} {topic}"[:120],
+            "summary": body[:4000],
+            "topic": tag,
+            "meeting": topic,
+            "date": date_dot.replace(".", "-"),
+        })
+    df = pd.DataFrame(rows)
+    types = {"title": "title", "summary": "semantic", "topic": "categoric",
+             "meeting": "categoric", "date": "date"}
+    return df, types
+
+
+if __name__ == "__main__":
+    # standalone smoke: print row counts for each source (proves the pullers work).
+    os.environ.setdefault("GITHUB_TOKEN", "")
+    nb, _ = meeting_notes()
+    print(f"meeting_notes: {len(nb)} dated entries")
+    if os.environ.get("GITHUB_TOKEN"):
+        prs, _ = github_prs()
+        iss, _ = github_issues()
+        print(f"github_prs: {len(prs)} | github_issues: {len(iss)}")
+    auth, _ = github_authors(os.environ.get("MANTISAPI_PATH", "."))
+    print(f"github_authors: {len(auth)} contributors")

--- a/examples/repo_radar/sources.py
+++ b/examples/repo_radar/sources.py
@@ -53,9 +53,12 @@ def github_prs(repos: list[str] = REPOS, state: str = "all") -> tuple[pd.DataFra
     for repo in repos:
         for pr in _paginate(f"{_API}/repos/{repo}/pulls", {"state": state, "sort": "updated"}):
             body = (pr.get("body") or "").strip()
+            # the semantic field must never be empty (the backend needs content to embed); many
+            # PRs have no body, so fall back to the title — which is the richest signal anyway.
+            summary = body or pr.get("title", "")
             rows.append({
                 "title": f"#{pr['number']} {pr['title']}",
-                "summary": body[:2000],
+                "summary": summary[:2000],
                 "repo": repo.split("/")[-1],
                 "author": pr["user"]["login"] if pr.get("user") else "unknown",
                 "state": "merged" if pr.get("merged_at") else pr.get("state", "open"),
@@ -82,9 +85,10 @@ def github_issues(repos: list[str] = REPOS, state: str = "all") -> tuple[pd.Data
             if "pull_request" in it:  # the issues endpoint includes PRs — drop them
                 continue
             body = (it.get("body") or "").strip()
+            summary = body or it.get("title", "")  # semantic field must be non-empty (see github_prs)
             rows.append({
                 "title": f"#{it['number']} {it['title']}",
-                "summary": body[:2000],
+                "summary": summary[:2000],
                 "repo": repo.split("/")[-1],
                 "author": it["user"]["login"] if it.get("user") else "unknown",
                 "state": it.get("state", "open"),

--- a/examples/repo_radar/sources.py
+++ b/examples/repo_radar/sources.py
@@ -1,9 +1,9 @@
 """data sources for the Mantis-on-Mantis demo (repo_radar).
 
 pulls four real corpora into pandas DataFrames ready for client.spaces.create():
-  - github_prs / github_issues  : open + recent PRs/issues across both repos (GitHub REST)
-  - github_authors              : per-author contribution rollup from local git history
-  - meeting_notes               : the Mantis meeting-notes Google Doc, split into dated entries
+  - github_prs / github_issues  : ALL active (open) PRs/issues across both repos (GitHub REST)
+  - github_authors              : everyone who ever committed to either repo (GitHub REST)
+  - meeting_notes               : the Mantis meeting-notes Google Doc, one point per segment
 
 each returns (df, data_types) so the caller just hands it to the SDK. no SDK imports here —
 this is plain ingestion so it can be tested / run standalone."""
@@ -11,7 +11,6 @@ from __future__ import annotations
 
 import os
 import re
-import subprocess
 import time
 from typing import Any
 
@@ -47,11 +46,12 @@ def _paginate(url: str, params: dict[str, Any], max_pages: int = 5) -> list[dict
 
 
 # ----------------------------------------------------------------------------- github PRs
-def github_prs(repos: list[str] = REPOS, state: str = "all") -> tuple[pd.DataFrame, dict]:
-    """open + recent PRs across the repos. title is semantic; state/repo/author categoric."""
+def github_prs(repos: list[str] = REPOS, state: str = "open") -> tuple[pd.DataFrame, dict]:
+    """ALL currently-active (open) PRs across the repos, each with its open/update dates.
+    title is semantic; repo/author/labels categoric; created_at/updated_at are date facets."""
     rows = []
     for repo in repos:
-        for pr in _paginate(f"{_API}/repos/{repo}/pulls", {"state": state, "sort": "updated"}):
+        for pr in _paginate(f"{_API}/repos/{repo}/pulls", {"state": state, "sort": "created", "direction": "desc"}):
             body = (pr.get("body") or "").strip()
             # the semantic field must never be empty (the backend needs content to embed); many
             # PRs have no body, so fall back to the title — which is the richest signal anyway.
@@ -61,27 +61,28 @@ def github_prs(repos: list[str] = REPOS, state: str = "all") -> tuple[pd.DataFra
                 "summary": summary[:2000],
                 "repo": repo.split("/")[-1],
                 "author": pr["user"]["login"] if pr.get("user") else "unknown",
-                "state": "merged" if pr.get("merged_at") else pr.get("state", "open"),
-                "draft": str(bool(pr.get("draft"))),
+                "state": "draft" if pr.get("draft") else "open",
                 "labels": ", ".join(lbl["name"] for lbl in pr.get("labels", [])) or "none",
                 "created_at": (pr.get("created_at") or "")[:10],
+                "updated_at": (pr.get("updated_at") or "")[:10],
                 "url": pr.get("html_url", ""),
             })
     df = pd.DataFrame(rows)
     types = {
         "title": "title", "summary": "semantic", "repo": "categoric", "author": "categoric",
-        "state": "categoric", "draft": "categoric", "labels": "categoric",
-        "created_at": "date", "url": "links",
+        "state": "categoric", "labels": "categoric",
+        "created_at": "date", "updated_at": "date", "url": "links",
     }
     return df, types
 
 
 # --------------------------------------------------------------------------- github issues
-def github_issues(repos: list[str] = REPOS, state: str = "all") -> tuple[pd.DataFrame, dict]:
-    """issues only (the issues endpoint returns PRs too; we filter them out)."""
+def github_issues(repos: list[str] = REPOS, state: str = "open") -> tuple[pd.DataFrame, dict]:
+    """ALL currently-active (open) issues across the repos, each with its open/update dates.
+    the issues endpoint returns PRs too; we filter them out."""
     rows = []
     for repo in repos:
-        for it in _paginate(f"{_API}/repos/{repo}/issues", {"state": state, "sort": "updated"}):
+        for it in _paginate(f"{_API}/repos/{repo}/issues", {"state": state, "sort": "created", "direction": "desc"}):
             if "pull_request" in it:  # the issues endpoint includes PRs — drop them
                 continue
             body = (it.get("body") or "").strip()
@@ -95,104 +96,128 @@ def github_issues(repos: list[str] = REPOS, state: str = "all") -> tuple[pd.Data
                 "labels": ", ".join(lbl["name"] for lbl in it.get("labels", [])) or "none",
                 "comments": it.get("comments", 0),
                 "created_at": (it.get("created_at") or "")[:10],
+                "updated_at": (it.get("updated_at") or "")[:10],
                 "url": it.get("html_url", ""),
             })
     df = pd.DataFrame(rows)
     types = {
         "title": "title", "summary": "semantic", "repo": "categoric", "author": "categoric",
         "state": "categoric", "labels": "categoric", "comments": "numeric",
-        "created_at": "date", "url": "links",
+        "created_at": "date", "updated_at": "date", "url": "links",
     }
     return df, types
 
 
 # ------------------------------------------------------------------------- git author rollup
-def github_authors(repo_path: str, since_days: int = 90) -> tuple[pd.DataFrame, dict]:
-    """per-author contribution rollup from the LOCAL git clone (no API needed).
-    one point per author; commit count is numeric so the map can size/color by activity.
+def github_authors(repos: list[str] = REPOS, max_commit_pages: int = 10) -> tuple[pd.DataFrame, dict]:
+    """EVERYONE who has ever committed to either repo, via the GitHub API (no local clone).
 
-    raises ValueError (not CalledProcessError) if repo_path isn't a git repo, so the caller's
-    'one source failed, skip it' handling kicks in cleanly."""
-    import os.path
-
-    fmt = "%an\t%s"
-    if not os.path.isdir(os.path.join(repo_path, ".git")):
-        raise ValueError(
-            f"MANTISAPI_PATH={repo_path!r} is not a git checkout — set it to your local "
-            f"MantisAPI clone (e.g. ~/Mantis/MantisAPI)."
-        )
-    proc = subprocess.run(
-        ["git", "-C", repo_path, "log", f"--since={since_days} days ago", f"--format={fmt}"],
-        capture_output=True, text=True, check=False,
-    )
-    if proc.returncode != 0:
-        raise ValueError(f"git log failed in {repo_path!r}: {proc.stderr.strip()[:200]}")
-    out = proc.stdout.strip().splitlines()
-
+    the /contributors endpoint is the authoritative all-time roster (so the list is complete);
+    a bounded pass over /commits enriches each author with what they actually worked on and
+    their latest commit date. authors past the commit cap still appear (from /contributors),
+    just with a generic summary — we log when that truncation happens so it isn't silent."""
     agg: dict[str, dict] = {}
-    for line in out:
-        if "\t" not in line:
-            continue
-        author, subject = line.split("\t", 1)
-        a = agg.setdefault(author, {"commits": 0, "subjects": []})
-        a["commits"] += 1
-        a["subjects"].append(subject)
 
-    rows = [
-        {
-            "title": author,
-            "summary": " • ".join(d["subjects"][:40]),  # what they actually worked on
+    def _row(login: str) -> dict:
+        return agg.setdefault(login, {"commits": 0, "repos": set(), "subjects": [], "last": ""})
+
+    # 1) authoritative all-time roster + total contribution counts.
+    for repo in repos:
+        for c in _paginate(f"{_API}/repos/{repo}/contributors", {}):
+            login = c.get("login") or "unknown"
+            r = _row(login)
+            r["commits"] += int(c.get("contributions", 0))
+            r["repos"].add(repo.split("/")[-1])
+
+    # 2) enrich with commit subjects + latest date (bounded; union of authors is already complete).
+    enriched = set()
+    for repo in repos:
+        commits = _paginate(f"{_API}/repos/{repo}/commits", {}, max_pages=max_commit_pages)
+        if len(commits) >= max_commit_pages * 100:
+            print(f"  [authors] note: /commits for {repo} hit the {max_commit_pages*100}-commit "
+                  f"cap — older subjects omitted (roster stays complete via /contributors)")
+        for c in commits:
+            login = (c.get("author") or {}).get("login") or (c.get("commit", {}).get("author", {}).get("name") or "unknown")
+            r = _row(login)
+            msg = (c.get("commit", {}).get("message") or "").splitlines()[0] if c.get("commit") else ""
+            if msg and len(r["subjects"]) < 40:
+                r["subjects"].append(msg)
+            date = (c.get("commit", {}).get("author", {}).get("date") or "")[:10]
+            if date and date > r["last"]:
+                r["last"] = date
+            enriched.add(login)
+
+    rows = []
+    for login, d in agg.items():
+        repos_str = ", ".join(sorted(d["repos"])) or "—"
+        summary = " • ".join(d["subjects"]) if d["subjects"] else f"{login} — {d['commits']} commits to {repos_str}"
+        rows.append({
+            "title": login,
+            "summary": summary,
             "commits": d["commits"],
-            "author": author,
-        }
-        for author, d in agg.items()
-    ]
+            "repos": repos_str,
+            "author": login,
+            "last_commit": d["last"],
+        })
     df = pd.DataFrame(rows).sort_values("commits", ascending=False) if rows else pd.DataFrame(rows)
-    types = {"title": "title", "summary": "semantic", "commits": "numeric", "author": "categoric"}
+    types = {"title": "title", "summary": "semantic", "commits": "numeric",
+             "repos": "categoric", "author": "categoric", "last_commit": "date"}
     return df, types
 
 
 # ----------------------------------------------------------------------------- meeting notes
-def meeting_notes(gdoc_id: str = GDOC_ID) -> tuple[pd.DataFrame, dict]:
-    """the Mantis meeting-notes Google Doc, split into one point per dated meeting.
+# a meeting heading like "2026.06.10 Wed5pm Mantis Leadership".
+_MEETING_HEADING = re.compile(r"^(20\d\d\.\d\d\.\d\d)\s+\S+\s+(.*)$", re.MULTILINE)
+# a numbered segment line: "7. Topic Title - Speaker A, Speaker B (0:14:19): body…".
+_SEGMENT = re.compile(
+    r"^\s*\d+\.\s+(?P<title>.+?)\s+-\s+(?P<speakers>[^()]+?)\s+\((?P<ts>\d+:\d{2}(?::\d{2})?)\):\s+(?P<body>.+)$",
+    re.MULTILINE,
+)
 
-    the doc uses headings like '2026.06.10 Wed5pm Mantis Leadership' — we split on those
-    and treat the body as the semantic field, the topic + date as facets."""
+
+def meeting_notes(gdoc_id: str = GDOC_ID) -> tuple[pd.DataFrame, dict]:
+    """the Mantis meeting-notes Google Doc as ONE POINT PER SPEAKER SEGMENT.
+
+    each meeting is a dated heading followed by numbered segments of the form
+    'N. Title - Speakers (timestamp): discussion…'. we emit one row per segment so the map
+    captures who said what, when — the body is semantic; speakers/meeting/date are facets."""
     url = f"https://docs.google.com/document/d/{gdoc_id}/export?format=txt"
     text = requests.get(url, timeout=30).text
 
-    # split on date-prefixed headings: 2026.06.10 ...
-    heading = re.compile(r"^(20\d\d\.\d\d\.\d\d)\s+(\w+)\s+(.*)$", re.MULTILINE)
-    matches = list(heading.finditer(text))
+    meetings = list(_MEETING_HEADING.finditer(text))
     rows = []
-    for i, m in enumerate(matches):
-        start = m.end()
-        end = matches[i + 1].start() if i + 1 < len(matches) else len(text)
-        body = text[start:end].strip()
-        date_dot, topic = m.group(1), m.group(3).strip()  # group(2) is the weekday, unused
-        # topic looks like "Mantis Leadership" / "Mantis Agents Embeddings" — last word is a useful tag
-        tag = topic.replace("Mantis", "").strip().split()[0] if topic.replace("Mantis", "").strip() else "General"
-        rows.append({
-            "title": f"{date_dot} {topic}"[:120],
-            "summary": body[:4000],
-            "topic": tag,
-            "meeting": topic,
-            "date": date_dot.replace(".", "-"),
-        })
+    for i, m in enumerate(meetings):
+        start, end = m.end(), (meetings[i + 1].start() if i + 1 < len(meetings) else len(text))
+        date_dot, meeting = m.group(1), m.group(2).strip()
+        date = date_dot.replace(".", "-")
+        for seg in _SEGMENT.finditer(text[start:end]):
+            speakers = ", ".join(s.strip() for s in seg.group("speakers").split(","))
+            primary = speakers.split(",")[0].strip() if speakers else "unknown"
+            rows.append({
+                "title": f"{date} · {seg.group('title').strip()}"[:120],
+                "summary": seg.group("body").strip()[:4000],
+                "speakers": speakers,
+                "primary_speaker": primary,
+                "meeting": meeting,
+                "timestamp": seg.group("ts"),
+                "date": date,
+            })
     df = pd.DataFrame(rows)
-    types = {"title": "title", "summary": "semantic", "topic": "categoric",
-             "meeting": "categoric", "date": "date"}
+    types = {"title": "title", "summary": "semantic", "speakers": "categoric",
+             "primary_speaker": "categoric", "meeting": "categoric",
+             "timestamp": "categoric", "date": "date"}
     return df, types
 
 
 if __name__ == "__main__":
     # standalone smoke: print row counts for each source (proves the pullers work).
-    os.environ.setdefault("GITHUB_TOKEN", "")
     nb, _ = meeting_notes()
-    print(f"meeting_notes: {len(nb)} dated entries")
+    print(f"meeting_notes: {len(nb)} speaker segments")
     if os.environ.get("GITHUB_TOKEN"):
         prs, _ = github_prs()
         iss, _ = github_issues()
-        print(f"github_prs: {len(prs)} | github_issues: {len(iss)}")
-    auth, _ = github_authors(os.environ.get("MANTISAPI_PATH", "."))
-    print(f"github_authors: {len(auth)} contributors")
+        auth, _ = github_authors()
+        print(f"github_prs(open): {len(prs)} | github_issues(open): {len(iss)} | "
+              f"authors(all-time): {len(auth)}")
+    else:
+        print("set GITHUB_TOKEN to smoke-test the github pullers")

--- a/examples/repo_radar/sources.py
+++ b/examples/repo_radar/sources.py
@@ -219,26 +219,26 @@ _MAX_SNIPPET = 1200  # chars of file content to embed
 _MAX_FILES = 800  # cap total files to keep embedding time reasonable
 
 
-def _build_file_commit_stats(repos: list[str], max_commits: int = 50) -> dict[str, dict]:
-    """Build per-file stats (top_author, last_author, last_updated) from recent commit details.
+def _build_file_commit_stats(repos: list[str], max_pages: int = 5) -> dict[str, dict]:
+    """Build per-file stats (top_author, last_author, last_updated) from recent commits.
 
-    Fetches the last `max_commits` commits per repo with their file lists (one API call each)
-    to build author/date metadata per file path."""
+    Uses the per-file /commits?path= endpoint for each candidate file — but that's too slow
+    for 800 files. Instead we fetch the last ~500 commits' details (5 pages × 100) and record
+    which files each touched. Files not in recent history get 'unknown'."""
     from collections import Counter
     file_authors: dict[str, list[str]] = {}
     file_dates: dict[str, str] = {}
 
     for repo in repos:
         repo_short = repo.split("/")[-1]
-        # get recent commit SHAs
-        commits = _paginate(f"{_API}/repos/{repo}/commits", {}, max_pages=1)[:max_commits]
-        for commit in commits:
+        commits = _paginate(f"{_API}/repos/{repo}/commits", {}, max_pages=max_pages)
+        print(f"  [code-stats] {repo_short}: fetching details for {len(commits)} commits...")
+        for i, commit in enumerate(commits):
             sha = commit.get("sha")
             login = (commit.get("author") or {}).get("login") or "unknown"
             date = (commit.get("commit", {}).get("author", {}).get("date") or "")[:10]
             if not sha:
                 continue
-            # fetch detail to get files list
             try:
                 detail = requests.get(
                     f"{_API}/repos/{repo}/commits/{sha}",
@@ -254,7 +254,9 @@ def _build_file_commit_stats(repos: list[str], max_commits: int = 50) -> dict[st
                 file_authors.setdefault(key, []).append(login)
                 if date and (not file_dates.get(key) or date > file_dates[key]):
                     file_dates[key] = date
-            time.sleep(0.05)
+            if i % 50 == 49:
+                print(f"  [code-stats] {repo_short}: {i+1}/{len(commits)} commits processed")
+            time.sleep(0.02)
 
     stats = {}
     for key, authors in file_authors.items():
@@ -264,6 +266,7 @@ def _build_file_commit_stats(repos: list[str], max_commits: int = 50) -> dict[st
             "last_author": authors[0],
             "last_updated": file_dates.get(key, ""),
         }
+    print(f"  [code-stats] built stats for {len(stats)} files")
     return stats
 
 

--- a/examples/repo_radar/sources.py
+++ b/examples/repo_radar/sources.py
@@ -17,7 +17,7 @@ from typing import Any
 import pandas as pd
 import requests
 
-REPOS = ["KellisLab/MantisAPI", "KellisLab/Mantis"]
+REPOS = ["KellisLab/MantisAPI", "KellisLab/Mantis", "KellisLab/Mantis_SDK"]
 GDOC_ID = "1phoQhus36Dc3SEsFCE4V18YDjxEadwXekn-VCZu0d3o"
 _API = "https://api.github.com"
 

--- a/mantis_sdk/agents.py
+++ b/mantis_sdk/agents.py
@@ -130,6 +130,7 @@ class AgentSession:
         self.mode = mode
         self._ws = None
         self._events: list[AgentEvent] = []
+        self.server_chat_id: str | None = None
 
     def _ws_url(self) -> str:
         cfg = self._resource.http.config
@@ -253,6 +254,10 @@ class AgentSession:
                 continue
             if not isinstance(data, dict):
                 continue
+
+            # capture the real Agno session_id from the first message that carries it
+            if "chat_id" in data and data["chat_id"]:
+                self.server_chat_id = data["chat_id"]
 
             event = AgentEvent.from_wire(data)
             # assert the backend didn't silently route to a different runtime.

--- a/mantis_sdk/agents.py
+++ b/mantis_sdk/agents.py
@@ -112,11 +112,16 @@ class AgentSession:
 
     def __init__(self, resource: AgentsResource, *, user_email: str, provider: Provider,
                  space_id: str | None, chat_id: str, timeout: float,
-                 all_spaces: bool = False, mode: str | None = None):
+                 all_spaces: bool = False, mode: str | None = None,
+                 space_state_id: str | None = None):
         self._resource = resource
         self.user_email = user_email
         self.provider = Provider(provider)
         self.space_id = space_id
+        # the composer only sets the agent's X-Space-State-ID (which its MCP tools need to know
+        # which space/map to act on) when ws/chat is given a space_state_id. without it the agent
+        # can talk but can't inspect the space.
+        self.space_state_id = space_state_id
         self.chat_id = chat_id
         self.timeout = timeout
         # all_spaces lets one agent reason across every accessible map at once (the backend's
@@ -133,6 +138,8 @@ class AgentSession:
         url = f"{ws_base}/ws/chat/{self.chat_id}/{quote(self.user_email, safe='')}/default/?model_id={self.provider.value}"
         if self.space_id:
             url += f"&space_id={self.space_id}"
+        if self.space_state_id:
+            url += f"&space_state_id={self.space_state_id}"
         return url
 
     async def __aenter__(self) -> AgentSession:
@@ -310,12 +317,20 @@ class AgentsResource:
                 timeout: float = 180.0,
                 check_capability: bool = True,
                 all_spaces: bool = False,
-                mode: str | None = None) -> AgentSession:
+                mode: str | None = None,
+                space_state_id: str | None = None,
+                auto_space_state: bool = True) -> AgentSession:
         """open a streaming agent session. opencode by default; claude_code is checked up front.
 
         set all_spaces=True to let one agent reason across every accessible map at once (the
         backend's all-spaces composer; not possible in the single-space UI). `mode` selects a
         composer mode (e.g. "Orchestrator", "Ask") and triggers initialization on connect.
+
+        when scoped to a space_id, the agent's MCP tools need a space-state id to know which
+        space/map to act on. by default (auto_space_state=True) we mint one via
+        client.space_states.create() — the same cookie-auth endpoint the browser uses — and
+        thread it onto the connect. pass space_state_id to reuse an existing one, or
+        auto_space_state=False to skip (the agent can talk but not inspect the space).
 
         user_email is required (identity for capability gating); falls back to config.user_email.
         agents key on email, not user_id."""
@@ -328,10 +343,12 @@ class AgentsResource:
             )
         if check_capability:
             self._assert_available(user_email, provider)
+        if space_id and not space_state_id and not all_spaces and auto_space_state:
+            space_state_id = self._client.space_states.create(space_id, name="SDK agent")
         return AgentSession(
             self, user_email=user_email, provider=provider, space_id=space_id,
             chat_id=chat_id or f"sdk-{uuid.uuid4()}", timeout=timeout,
-            all_spaces=all_spaces, mode=mode,
+            all_spaces=all_spaces, mode=mode, space_state_id=space_state_id,
         )
 
     def run_sync(self, message: str, space_id: str | None = None, *,

--- a/mantis_sdk/agents.py
+++ b/mantis_sdk/agents.py
@@ -198,6 +198,9 @@ class AgentSession:
 
     async def close(self) -> None:
         if self._ws is not None:
+            import asyncio
+            # allow Agno time to persist the session before the WS disconnects
+            await asyncio.sleep(2)
             await self._ws.close()
             self._ws = None
 

--- a/mantis_sdk/agents.py
+++ b/mantis_sdk/agents.py
@@ -18,7 +18,6 @@ from __future__ import annotations
 import json
 import logging
 import time
-import uuid
 from collections.abc import AsyncIterator
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any

--- a/mantis_sdk/agents.py
+++ b/mantis_sdk/agents.py
@@ -55,6 +55,13 @@ class AgentEvent:
     def from_wire(cls, data: dict) -> AgentEvent:
         wire = data.get("type", "")
         provider = data.get("provider")
+        # the agent runtime streams assistant text as untyped {sender:"ai", message, partial}
+        # frames (no "type" key). surface only the FINAL frame (partial=false) as text so we
+        # don't double-count the streaming snapshots.
+        if not wire and data.get("sender") == "ai" and "message" in data:
+            if data.get("partial"):
+                return cls("typing", provider=provider, raw=data)
+            return cls("text", text=data.get("message", "") or "", provider=provider, raw=data)
         if wire in _TEXT_TYPES:
             return cls("text", text=data.get("content", "") or "", provider=provider, raw=data)
         if wire == "tool_use":
@@ -67,7 +74,8 @@ class AgentEvent:
             return cls("thinking", text=data.get("content", "") or "", provider=provider, raw=data)
         if wire == "agent_session_init":
             return cls("init", provider=provider, raw=data)
-        if wire == "typing_indicator":
+        if wire in ("typing_indicator", "heartbeat"):
+            # heartbeats keep the socket alive during a long claude_code/opencode run.
             return cls("typing", provider=provider, raw=data)
         if wire == "chat_complete":
             return cls("complete", text=data.get("content", "") or "", provider=provider, raw=data)
@@ -103,13 +111,18 @@ class AgentSession:
     """
 
     def __init__(self, resource: AgentsResource, *, user_email: str, provider: Provider,
-                 space_id: str | None, chat_id: str, timeout: float):
+                 space_id: str | None, chat_id: str, timeout: float,
+                 all_spaces: bool = False, mode: str | None = None):
         self._resource = resource
         self.user_email = user_email
         self.provider = Provider(provider)
         self.space_id = space_id
         self.chat_id = chat_id
         self.timeout = timeout
+        # all_spaces lets one agent reason across every accessible map at once (the backend's
+        # initialize_all_spaces_agent path) — not possible in the single-space UI.
+        self.all_spaces = all_spaces
+        self.mode = mode
         self._ws = None
         self._events: list[AgentEvent] = []
 
@@ -127,10 +140,50 @@ class AgentSession:
 
         cookie = self._resource.http.cookie
         headers = {"Cookie": cookie} if cookie else None
-        self._ws = await websockets.connect(
-            self._ws_url(), additional_headers=headers, max_size=None, open_timeout=self.timeout
-        )
+        # the header kwarg was renamed extra_headers → additional_headers in websockets 14.
+        # try the new name, fall back to the old so we work across the pinned range (>=10.4).
+        try:
+            self._ws = await websockets.connect(
+                self._ws_url(), additional_headers=headers, max_size=None, open_timeout=self.timeout,
+            )
+        except TypeError:
+            self._ws = await websockets.connect(
+                self._ws_url(), extra_headers=headers, max_size=None, open_timeout=self.timeout,
+            )
+        # initialize the composer agent when an explicit mode or all_spaces is requested.
+        # the backend routes all_spaces_mode → initialize_all_spaces_agent (cross-map search).
+        if self.all_spaces or self.mode:
+            await self._initialize()
         return self
+
+    async def _initialize(self, ack_timeout: float = 30.0) -> None:
+        """send agent_initialization; wait (best-effort) for the agent_initialized ack.
+
+        the backend delivers the ack via a channel-layer group broadcast, which may or may not
+        loop back to a headless single socket depending on the deployment. so we wait up to
+        ack_timeout for it, but if it doesn't arrive we proceed anyway (the backend still
+        processed the init) rather than failing the whole run. a `success=false` ack IS fatal."""
+        import asyncio
+
+        init: dict[str, Any] = {"type": "agent_initialization", "all_spaces_mode": self.all_spaces}
+        if self.mode:
+            init["mode"] = self.mode
+        await self._ws.send(json.dumps(init))
+        deadline = time.monotonic() + ack_timeout
+        while time.monotonic() < deadline:
+            try:
+                raw = await asyncio.wait_for(self._ws.recv(), timeout=deadline - time.monotonic())
+            except asyncio.TimeoutError:
+                logger.debug("agent_initialized ack not received in %.0fs; proceeding", ack_timeout)
+                return
+            try:
+                data = json.loads(raw)
+            except (ValueError, TypeError):
+                continue
+            if isinstance(data, dict) and data.get("type") == "agent_initialized":
+                if not data.get("success", True):
+                    raise AgentRunError(f"agent initialization failed: {data.get('error')}")
+                return
 
     async def __aexit__(self, *exc: Any) -> None:
         await self.close()
@@ -166,15 +219,16 @@ class AgentSession:
 
         await self._ws.send(json.dumps(payload))
 
-        deadline = time.monotonic() + self.timeout
+        # idle timeout: a long claude_code/opencode run can take minutes, but the backend sends
+        # heartbeats, so we bound on SILENCE (no event for `self.timeout`s), not total duration.
         while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                raise AgentRunError(f"agent run timed out after {self.timeout}s")
             try:
-                raw = await asyncio.wait_for(self._ws.recv(), timeout=remaining)
+                raw = await asyncio.wait_for(self._ws.recv(), timeout=self.timeout)
             except asyncio.TimeoutError as exc:
-                raise AgentRunError(f"agent run timed out after {self.timeout}s") from exc
+                raise AgentRunError(
+                    f"agent run idle for {self.timeout}s with no event (backend sends heartbeats; "
+                    f"a longer idle timeout or a stuck run?)"
+                ) from exc
 
             try:
                 data = json.loads(raw)
@@ -254,11 +308,17 @@ class AgentsResource:
                 user_email: str | None = None,
                 chat_id: str | None = None,
                 timeout: float = 180.0,
-                check_capability: bool = True) -> AgentSession:
+                check_capability: bool = True,
+                all_spaces: bool = False,
+                mode: str | None = None) -> AgentSession:
         """open a streaming agent session. opencode by default; claude_code is checked up front.
 
-        user_email is required (identity for capability gating); falls back to MANTIS_USER_EMAIL
-        via the config's internal_user_id is NOT valid here — agents key on email, not user_id."""
+        set all_spaces=True to let one agent reason across every accessible map at once (the
+        backend's all-spaces composer; not possible in the single-space UI). `mode` selects a
+        composer mode (e.g. "Orchestrator", "Ask") and triggers initialization on connect.
+
+        user_email is required (identity for capability gating); falls back to config.user_email.
+        agents key on email, not user_id."""
         provider = Provider(provider)
         user_email = user_email or getattr(self.http.config, "user_email", None)
         if not user_email:
@@ -271,6 +331,7 @@ class AgentsResource:
         return AgentSession(
             self, user_email=user_email, provider=provider, space_id=space_id,
             chat_id=chat_id or f"sdk-{uuid.uuid4()}", timeout=timeout,
+            all_spaces=all_spaces, mode=mode,
         )
 
     def run_sync(self, message: str, space_id: str | None = None, *,

--- a/mantis_sdk/agents.py
+++ b/mantis_sdk/agents.py
@@ -365,7 +365,7 @@ class AgentsResource:
             space_state_id = self._client.space_states.create(space_id, name="SDK agent")
         return AgentSession(
             self, user_email=user_email, provider=provider, space_id=space_id,
-            chat_id=chat_id or f"sdk-{uuid.uuid4()}", timeout=timeout,
+            chat_id=chat_id or "new", timeout=timeout,
             all_spaces=all_spaces, mode=mode, space_state_id=space_state_id,
         )
 

--- a/mantis_sdk/agents.py
+++ b/mantis_sdk/agents.py
@@ -228,10 +228,20 @@ class AgentSession:
 
         # idle timeout: a long claude_code/opencode run can take minutes, but the backend sends
         # heartbeats, so we bound on SILENCE (no event for `self.timeout`s), not total duration.
+        # final-answer grace: the backend sends the committed final text (a non-partial ai frame)
+        # and *then* a chat_complete envelope — but that envelope is delivered over a kafka→socket
+        # bridge that occasionally drops it, leaving us blocked on recv() for the full idle
+        # timeout AFTER the answer already arrived. so once we've seen the final text, we wait
+        # only `final_grace`s for a terminal event, then finish cleanly.
+        saw_final_text = False
+        final_grace = getattr(self, "final_grace", 8.0)
         while True:
+            wait = final_grace if saw_final_text else self.timeout
             try:
-                raw = await asyncio.wait_for(self._ws.recv(), timeout=self.timeout)
+                raw = await asyncio.wait_for(self._ws.recv(), timeout=wait)
             except asyncio.TimeoutError as exc:
+                if saw_final_text:
+                    return  # answer already delivered; the terminal envelope just didn't arrive
                 raise AgentRunError(
                     f"agent run idle for {self.timeout}s with no event (backend sends heartbeats; "
                     f"a longer idle timeout or a stuck run?)"
@@ -255,6 +265,9 @@ class AgentSession:
             yield event
             if event.is_terminal:
                 return
+            # a committed final answer frame ({sender:ai, partial:false}) → start the grace clock.
+            if event.type == "text" and data.get("sender") == "ai" and data.get("partial") is False:
+                saw_final_text = True
 
     def result(self) -> AgentResult:
         """assemble the full assistant text + outcome from the events seen so far."""

--- a/mantis_sdk/client.py
+++ b/mantis_sdk/client.py
@@ -21,6 +21,7 @@ from .enums import AIProvider, DataType, Provider, ReducerModels, SpacePrivacy
 from .exceptions import ConfigurationError
 from .notebook import NotebooksResource
 from .resources import (
+    AliasesResource,
     AnnotationsResource,
     MapsResource,
     SearchResource,
@@ -68,6 +69,7 @@ class MantisClient:
         self.spaces = SpacesResource(self)
         self.maps = MapsResource(self)
         self.space_states = SpaceStatesResource(self)
+        self.aliases = AliasesResource(self)
         self.annotations = AnnotationsResource(self)
         self.search = SearchResource(self)
         self.notebooks = NotebooksResource(self)

--- a/mantis_sdk/client.py
+++ b/mantis_sdk/client.py
@@ -23,6 +23,7 @@ from .notebook import NotebooksResource
 from .resources import (
     AliasesResource,
     AnnotationsResource,
+    FeaturedChatResource,
     MapsResource,
     SearchResource,
     SpaceHandle,
@@ -70,6 +71,7 @@ class MantisClient:
         self.maps = MapsResource(self)
         self.space_states = SpaceStatesResource(self)
         self.aliases = AliasesResource(self)
+        self.featured_chat = FeaturedChatResource(self)
         self.annotations = AnnotationsResource(self)
         self.search = SearchResource(self)
         self.notebooks = NotebooksResource(self)

--- a/mantis_sdk/client.py
+++ b/mantis_sdk/client.py
@@ -26,6 +26,7 @@ from .resources import (
     SearchResource,
     SpaceHandle,
     SpacesResource,
+    SpaceStatesResource,
 )
 
 logger = logging.getLogger("mantis_sdk")
@@ -66,6 +67,7 @@ class MantisClient:
         # resource groups.
         self.spaces = SpacesResource(self)
         self.maps = MapsResource(self)
+        self.space_states = SpaceStatesResource(self)
         self.annotations = AnnotationsResource(self)
         self.search = SearchResource(self)
         self.notebooks = NotebooksResource(self)

--- a/mantis_sdk/resources.py
+++ b/mantis_sdk/resources.py
@@ -140,6 +140,7 @@ class SpacesResource(_BaseResource):
         stall_timeout: float | None = 600.0,
         space_id: str | None = None,
         map_id: str | None = None,
+        map_name: str | None = None,
     ) -> SpaceHandle:
         """create a space from a DataFrame or csv path, then (by default) poll to completion.
 
@@ -149,7 +150,10 @@ class SpacesResource(_BaseResource):
         pass an explicit space_id to add this map to an EXISTING space (the backend
         get_or_creates the space, so reusing a space_id is idempotent). pass a stable map_id
         to refresh that map in place on re-runs (the backend updates the map of that id rather
-        than creating a new one) — this is how you keep one space with a fixed set of maps."""
+        than creating a new one) — this is how you keep one space with a fixed set of maps.
+
+        map_name names the map; without it the backend falls back to "Untitled Map". defaults
+        to space_name so a single-map space gets a sensible label out of the box."""
         buffer, columns, file_extension = self._load_data(data)
 
         data_types_sanitized = self._sanitize_data_types(columns, data_types)
@@ -170,6 +174,7 @@ class SpacesResource(_BaseResource):
         form_data = {
             "space_id": space_id,
             "space_name": space_name,
+            "map_name": map_name or space_name,  # backend defaults to "Untitled Map" if omitted
             "is_public": str(str(privacy_level) == str(SpacePrivacy.PUBLIC)).lower(),
             "red_model": str(reducer),
             "custom_models": json.dumps(custom_models),

--- a/mantis_sdk/resources.py
+++ b/mantis_sdk/resources.py
@@ -90,6 +90,7 @@ class MantisClientProtocol:
     spaces: SpacesResource
     annotations: AnnotationsResource
     space_states: SpaceStatesResource
+    aliases: AliasesResource
 
 
 class _BaseResource:
@@ -137,11 +138,18 @@ class SpacesResource(_BaseResource):
         show_progress: bool = False,
         wait: bool = True,
         stall_timeout: float | None = 600.0,
+        space_id: str | None = None,
+        map_id: str | None = None,
     ) -> SpaceHandle:
         """create a space from a DataFrame or csv path, then (by default) poll to completion.
 
         returns a SpaceHandle carrying space_id and map_id. set wait=False to return as soon
-        as the pipeline is enqueued. stall_timeout raises if progress stops advancing."""
+        as the pipeline is enqueued. stall_timeout raises if progress stops advancing.
+
+        pass an explicit space_id to add this map to an EXISTING space (the backend
+        get_or_creates the space, so reusing a space_id is idempotent). pass a stable map_id
+        to refresh that map in place on re-runs (the backend updates the map of that id rather
+        than creating a new one) — this is how you keep one space with a fixed set of maps."""
         buffer, columns, file_extension = self._load_data(data)
 
         data_types_sanitized = self._sanitize_data_types(columns, data_types)
@@ -156,7 +164,7 @@ class SpacesResource(_BaseResource):
                 f"columns ({len(data_types_sanitized)})"
             )
 
-        space_id = str(uuid.uuid4())
+        space_id = space_id or str(uuid.uuid4())
         file_key = f"{space_name}-{space_id}.{file_extension}"
 
         form_data = {
@@ -171,6 +179,8 @@ class SpacesResource(_BaseResource):
             "chat_model": chat_model,
             "embedding_model": embedding_model,
         }
+        if map_id:  # stable map id → backend refreshes that map in place instead of minting one
+            form_data["map_id"] = map_id
         files = {"file": (f"data.{file_extension}", buffer, f"text/{file_extension}")}
 
         resp = self.http.request("POST", "/synthesis/landscape", data=form_data, files=files)
@@ -367,6 +377,51 @@ class SpaceStatesResource(_BaseResource):
     def list(self, space_id: str) -> list[dict]:
         resp = self.http.request("GET", "/api/space-state", params={"space_id": space_id})
         return resp if isinstance(resp, list) else (resp or [])
+
+
+class AliasesResource(_BaseResource):
+    """human-friendly URL aliases for spaces (/space/<alias> resolves to the space).
+
+    lets a job maintain a STABLE url (e.g. /space/m4m) that always points at the same space.
+    set() is owner-only and (on a backend with the idempotency fix) safe to re-call on the
+    same space; resolve_or_create_space() encodes the idempotent recipe so re-runs don't make
+    duplicate spaces."""
+
+    def resolve(self, alias: str) -> str | None:
+        """alias → space_id, or None if no accessible space has it."""
+        try:
+            resp = self.http.request("GET", "/api/getSpaceFromAlias", params={"alias": alias})
+        except MantisError:
+            return None  # backend returns 400 when not found; treat as "no such alias"
+        return resp.get("project_id") if isinstance(resp, dict) else None
+
+    def get(self, space_id: str) -> str | None:
+        """space_id → its alias, or None."""
+        try:
+            resp = self.http.request("GET", "/api/getAliasFromSpaceId", params={"project_id": space_id})
+        except MantisError:
+            return None
+        return resp.get("alias") if isinstance(resp, dict) else None
+
+    def set(self, space_id: str, alias: str) -> Any:
+        """point an alias at a space (owner-only)."""
+        return self.http.request(
+            "POST", "/api/setSpaceAlias", json={"space_id": space_id, "alias": alias}
+        )
+
+    def resolve_or_create_space(self, alias: str) -> tuple[str, bool]:
+        """return (space_id, created) for `alias`, minting a DETERMINISTIC space id if absent.
+
+        the guardrail for idempotency: if the alias already resolves, reuse that space (and do
+        NOT re-set the alias — older backends 400 on that). otherwise derive a stable space id
+        from the alias (uuid5) so concurrent first-runs converge on one space instead of racing
+        to create two. the caller then creates maps into space_id and, only when created=True,
+        calls set(space_id, alias) once."""
+        existing = self.resolve(alias)
+        if existing:
+            return existing, False
+        space_id = str(uuid.uuid5(uuid.NAMESPACE_URL, f"mantis-sdk-alias:{alias}"))
+        return space_id, True
 
 
 class AnnotationsResource(_BaseResource):

--- a/mantis_sdk/resources.py
+++ b/mantis_sdk/resources.py
@@ -393,6 +393,35 @@ class SpaceStatesResource(_BaseResource):
         return resp if isinstance(resp, list) else (resp or [])
 
 
+class FeaturedChatResource(_BaseResource):
+    """pin a conversation to a space so it auto-loads for visitors."""
+
+    def get(self, space_id: str) -> dict:
+        """get the featured chat for a space. returns {featured_chat_id, user_chat_session_id}."""
+        return self.http.request("GET", "/api/featured-chat", params={"space_id": space_id})
+
+    def set(self, space_id: str, chat_id: str) -> dict:
+        """pin a chat as the space's featured conversation. clears all user copies."""
+        return self.http.request(
+            "PUT", "/api/featured-chat", json={"space_id": space_id, "chat_id": chat_id}
+        )
+
+    def clear(self, space_id: str) -> dict:
+        """remove the featured chat from a space."""
+        return self.http.request(
+            "DELETE", "/api/featured-chat", params={"space_id": space_id}
+        )
+
+    def clone(self, space_id: str) -> str:
+        """clone the featured chat for the current user. returns the new session_id."""
+        resp = self.http.request(
+            "POST", "/api/featured-chat/clone", json={"space_id": space_id}
+        )
+        if not isinstance(resp, dict) or "chat_session_id" not in resp:
+            raise MantisError(f"featured chat clone failed: {resp}")
+        return resp["chat_session_id"]
+
+
 class AliasesResource(_BaseResource):
     """human-friendly URL aliases for spaces (/space/<alias> resolves to the space).
 

--- a/mantis_sdk/resources.py
+++ b/mantis_sdk/resources.py
@@ -89,6 +89,7 @@ class MantisClientProtocol:
     http: HttpClient
     spaces: SpacesResource
     annotations: AnnotationsResource
+    space_states: SpaceStatesResource
 
 
 class _BaseResource:
@@ -344,6 +345,28 @@ class MapsResource(_BaseResource):
 
     def get_ideas(self, ids: list[str]) -> Any:
         return self.http.request("GET", "/api/getIdeas", params={"ids": ",".join(ids)})
+
+
+class SpaceStatesResource(_BaseResource):
+    """create/list space-states — a per-user live view of a space (selection, bags, active map).
+
+    agents need a space-state id so their MCP tools know which space/map to act on; the backend
+    only sets the X-Space-State-ID header when ws/chat is given a space_state_id. the browser
+    mints one when you open a space; a headless sdk session mints one here (same cookie-auth
+    endpoint the frontend uses)."""
+
+    def create(self, space_id: str, name: str = "SDK") -> str:
+        """create a space-state for a space and return its id."""
+        resp = self.http.request(
+            "POST", "/api/space-state", json={"space_id": space_id, "name": name}
+        )
+        if not isinstance(resp, dict) or "id" not in resp:
+            raise MantisError(f"space-state create returned no id: {resp}")
+        return resp["id"]
+
+    def list(self, space_id: str) -> list[dict]:
+        resp = self.http.request("GET", "/api/space-state", params={"space_id": space_id})
+        return resp if isinstance(resp, list) else (resp or [])
 
 
 class AnnotationsResource(_BaseResource):

--- a/mantis_sdk/resources.py
+++ b/mantis_sdk/resources.py
@@ -366,7 +366,14 @@ class SpaceStatesResource(_BaseResource):
     endpoint the frontend uses)."""
 
     def create(self, space_id: str, name: str = "SDK") -> str:
-        """create a space-state for a space and return its id."""
+        """get-or-create a space-state for (space, name) and return its id.
+
+        space-state is unique on (space, name, created_by), so blindly POSTing the same name
+        twice raises an integrity error (500) on re-runs. we reuse an existing state of this
+        name when present — making the call idempotent."""
+        for existing in self.list(space_id):
+            if isinstance(existing, dict) and existing.get("name") == name and existing.get("id"):
+                return existing["id"]
         resp = self.http.request(
             "POST", "/api/space-state", json={"space_id": space_id, "name": name}
         )
@@ -376,6 +383,8 @@ class SpaceStatesResource(_BaseResource):
 
     def list(self, space_id: str) -> list[dict]:
         resp = self.http.request("GET", "/api/space-state", params={"space_id": space_id})
+        if isinstance(resp, dict):
+            return resp.get("states", resp.get("results", []))
         return resp if isinstance(resp, list) else (resp or [])
 
 

--- a/mantis_sdk/resources.py
+++ b/mantis_sdk/resources.py
@@ -400,11 +400,17 @@ class FeaturedChatResource(_BaseResource):
         """get the featured chat for a space. returns {featured_chat_id, user_chat_session_id}."""
         return self.http.request("GET", "/api/featured-chat", params={"space_id": space_id})
 
-    def set(self, space_id: str, chat_id: str) -> dict:
-        """pin a chat as the space's featured conversation. clears all user copies."""
-        return self.http.request(
-            "PUT", "/api/featured-chat", json={"space_id": space_id, "chat_id": chat_id}
-        )
+    def set(self, space_id: str, chat_id: str, *, messages: list[dict] | None = None,
+            title: str | None = None) -> dict:
+        """pin a chat as the space's featured conversation. clears all user copies.
+
+        pass messages to ensure the chat is persisted (Agno may not have flushed yet)."""
+        payload: dict = {"space_id": space_id, "chat_id": chat_id}
+        if messages:
+            payload["messages"] = messages
+        if title:
+            payload["title"] = title
+        return self.http.request("PUT", "/api/featured-chat", json=payload)
 
     def clear(self, space_id: str) -> dict:
         """remove the featured chat from a space."""

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -112,7 +112,9 @@ class _FakeWS:
 
     async def recv(self):
         if not self._script:
-            raise AssertionError("recv called after script exhausted")
+            # mimic a live socket going quiet — block forever so wait_for() times out.
+            import asyncio
+            await asyncio.Event().wait()
         return self._script.pop(0)
 
     async def close(self):
@@ -158,6 +160,22 @@ async def test_ask_raises_on_provider_mismatch(client):
     with pytest.raises(ProviderUnavailableError, match="fallen back"):
         async for _ in sess.ask("hi"):
             pass
+
+
+@pytest.mark.asyncio
+async def test_ask_finishes_on_final_text_when_complete_dropped(client):
+    # backend sometimes drops the chat_complete envelope (kafka→socket bridge); after the
+    # committed final answer we should finish on a short grace, not hang the full idle timeout.
+    script = [
+        {"type": "chat_messages", "content": "partial", "provider": "opencode"},
+        {"sender": "ai", "message": "the final answer", "partial": False, "provider": "opencode"},
+        # no chat_complete — socket then goes silent (FakeWS blocks)
+    ]
+    sess = _session(client, script=script)
+    sess.final_grace = 0.05  # tiny grace so the test is fast
+    texts = [ev.text for ev in [e async for e in sess.ask("hi")] if ev.type == "text"]
+    assert "the final answer" in "".join(texts)
+    assert sess.result().text  # assembled despite no terminal event
 
 
 @pytest.mark.asyncio

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -39,6 +39,22 @@ def test_event_from_wire_unknown_passes_through():
     assert ev.type == "other" and ev.raw["x"] == 1
 
 
+def test_event_from_wire_ai_final_frame_is_text():
+    # the agent runtime streams assistant text as untyped {sender:ai, message, partial}.
+    final = AgentEvent.from_wire({"sender": "ai", "message": "done", "partial": False})
+    assert final.type == "text" and final.text == "done"
+
+
+def test_event_from_wire_ai_partial_frame_is_typing():
+    # partial snapshots should NOT be counted as text (avoid double-counting).
+    partial = AgentEvent.from_wire({"sender": "ai", "message": "do", "partial": True})
+    assert partial.type == "typing"
+
+
+def test_event_from_wire_heartbeat_is_typing():
+    assert AgentEvent.from_wire({"type": "heartbeat", "message_id": "x"}).type == "typing"
+
+
 # --- capability gating (REST via recording transport) ---
 
 def test_opencode_never_calls_capability_check(client, transport):
@@ -185,3 +201,29 @@ def test_ws_url_uses_email_path_and_provider(client):
 
 def test_default_provider_is_opencode():
     assert AgentsResource.DEFAULT_PROVIDER == Provider.OpenCode
+
+
+@pytest.mark.asyncio
+async def test_all_spaces_initialization_handshake(client):
+    # all_spaces=True must send agent_initialization{all_spaces_mode:true} and wait for the ack.
+    sess = client.agents.session(
+        provider=Provider.OpenCode, user_email="u@e.com", check_capability=False,
+        all_spaces=True, timeout=5,
+    )
+    sess._ws = _FakeWS([{"type": "agent_initialized", "success": True}])
+    await sess._initialize()
+    assert sess._ws.sent[0]["type"] == "agent_initialization"
+    assert sess._ws.sent[0]["all_spaces_mode"] is True
+
+
+@pytest.mark.asyncio
+async def test_initialization_failure_raises(client):
+    from mantis_sdk.exceptions import AgentRunError
+
+    sess = client.agents.session(
+        provider=Provider.OpenCode, user_email="u@e.com", check_capability=False,
+        all_spaces=True, timeout=5,
+    )
+    sess._ws = _FakeWS([{"type": "agent_initialized", "success": False, "error": "no spaces"}])
+    with pytest.raises(AgentRunError, match="initialization failed"):
+        await sess._initialize()

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -122,7 +122,7 @@ class _FakeWS:
 def _session(client, provider=Provider.OpenCode, script=None):
     sess = client.agents.session(
         "space1", provider=provider, user_email="u@e.com",
-        check_capability=False, timeout=5,
+        check_capability=False, timeout=5, auto_space_state=False,
     )
     sess._ws = _FakeWS(script or [])
     return sess
@@ -189,7 +189,7 @@ async def test_ask_sends_map_and_bag_scoping(client):
 def test_ws_url_uses_email_path_and_provider(client):
     sess = client.agents.session(
         "space1", provider=Provider.ClaudeCode, user_email="a+b@e.com",
-        check_capability=False,
+        check_capability=False, auto_space_state=False,
     )
     url = sess._ws_url()
     # email is url-encoded in the path; provider is the model_id; space is a query param.
@@ -201,6 +201,41 @@ def test_ws_url_uses_email_path_and_provider(client):
 
 def test_default_provider_is_opencode():
     assert AgentsResource.DEFAULT_PROVIDER == Provider.OpenCode
+
+
+def test_session_auto_creates_space_state(client, transport):
+    # scoping to a space should mint a space-state and thread it onto the ws url.
+    transport.queue = [{"id": "ss-123", "name": "SDK agent"}]  # space-state create response
+    sess = client.agents.session("space1", provider=Provider.OpenCode, user_email="u@e.com",
+                                 check_capability=False)
+    assert sess.space_state_id == "ss-123"
+    assert "space_state_id=ss-123" in sess._ws_url()
+    assert "space_id=space1" in sess._ws_url()
+    # it hit the cookie-auth space-state endpoint
+    assert transport.calls[0]["url"].endswith("/api/space-state/")
+
+
+def test_session_skips_space_state_when_disabled(client, transport):
+    sess = client.agents.session("space1", provider=Provider.OpenCode, user_email="u@e.com",
+                                 check_capability=False, auto_space_state=False)
+    assert sess.space_state_id is None
+    assert "space_state_id" not in sess._ws_url()
+    assert transport.calls == []  # no mint call
+
+
+def test_session_reuses_explicit_space_state(client, transport):
+    sess = client.agents.session("space1", provider=Provider.OpenCode, user_email="u@e.com",
+                                 check_capability=False, space_state_id="ss-explicit")
+    assert sess.space_state_id == "ss-explicit"
+    assert transport.calls == []  # no mint call — caller supplied one
+
+
+def test_all_spaces_does_not_mint_space_state(client, transport):
+    # all_spaces has no single space to scope, so no space-state is created.
+    sess = client.agents.session(provider=Provider.OpenCode, user_email="u@e.com",
+                                 check_capability=False, all_spaces=True)
+    assert sess.space_state_id is None
+    assert transport.calls == []
 
 
 @pytest.mark.asyncio

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -205,14 +205,23 @@ def test_default_provider_is_opencode():
 
 def test_session_auto_creates_space_state(client, transport):
     # scoping to a space should mint a space-state and thread it onto the ws url.
-    transport.queue = [{"id": "ss-123", "name": "SDK agent"}]  # space-state create response
+    # create() is get-or-create: it lists first (none exist), then POSTs.
+    transport.queue = [[], {"id": "ss-123", "name": "SDK agent"}]
     sess = client.agents.session("space1", provider=Provider.OpenCode, user_email="u@e.com",
                                  check_capability=False)
     assert sess.space_state_id == "ss-123"
     assert "space_state_id=ss-123" in sess._ws_url()
     assert "space_id=space1" in sess._ws_url()
     # it hit the cookie-auth space-state endpoint
-    assert transport.calls[0]["url"].endswith("/api/space-state/")
+    assert transport.calls[-1]["url"].endswith("/api/space-state/")
+
+
+def test_space_state_create_reuses_existing(client, transport):
+    # get-or-create: if a state with the same name exists, reuse it (no POST).
+    transport.queue = [[{"id": "ss-old", "name": "SDK agent"}]]
+    sid = client.space_states.create("space1", name="SDK agent")
+    assert sid == "ss-old"
+    assert len(transport.calls) == 1  # only the list GET, no create POST
 
 
 def test_session_skips_space_state_when_disabled(client, transport):

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -48,3 +48,65 @@ def test_ids_by_name_filters_by_privacy(client, transport):
 def test_ids_by_name_tolerates_legacy_space_id_key(client, transport):
     transport.queue = [{"private": [{"space_id": "s9", "space_name": "Foo"}]}]
     assert client.spaces.ids_by_name("Foo", ["private"]) == ["s9"]
+
+
+# --- aliases ---
+
+def test_alias_resolve_returns_space_id(client, transport):
+    transport.queue = [{"project_id": "sp-9"}]
+    assert client.aliases.resolve("m4m") == "sp-9"
+    assert transport.calls[0]["url"].endswith("/api/getSpaceFromAlias/")
+    assert transport.calls[0]["kwargs"]["params"]["alias"] == "m4m"
+
+
+def test_alias_resolve_missing_returns_none(client, transport):
+    # backend 400s when the alias isn't found → resolve() swallows to None.
+    from mantis_sdk.exceptions import APIStatusError
+
+    def boom(method, url, kwargs):
+        raise APIStatusError("not found", status_code=400, body={"project_id": None})
+
+    transport.responder = boom
+    assert client.aliases.resolve("nope") is None
+
+
+def test_alias_set_posts_body(client, transport):
+    transport.queue = [{"ok": True}]
+    client.aliases.set("sp-1", "m4m")
+    call = transport.calls[0]
+    assert call["url"].endswith("/api/setSpaceAlias/")
+    assert call["kwargs"]["json"] == {"space_id": "sp-1", "alias": "m4m"}
+
+
+def test_resolve_or_create_reuses_existing(client, transport):
+    transport.queue = [{"project_id": "existing-space"}]
+    space_id, created = client.aliases.resolve_or_create_space("m4m")
+    assert (space_id, created) == ("existing-space", False)
+
+
+def test_resolve_or_create_mints_deterministic(client, transport):
+    # alias not found → deterministic uuid5, created=True, and stable across calls.
+    from mantis_sdk.exceptions import APIStatusError
+
+    def notfound(method, url, kwargs):
+        raise APIStatusError("nf", status_code=400, body={})
+
+    transport.responder = notfound
+    a, created_a = client.aliases.resolve_or_create_space("m4m")
+    b, _ = client.aliases.resolve_or_create_space("m4m")
+    assert created_a is True
+    assert a == b  # deterministic — same alias always yields the same space id
+
+
+def test_create_passes_explicit_space_and_map_id(client, transport):
+    import pandas as pd
+
+    from mantis_sdk import DataType
+
+    transport.queue = [{"map_id": "m-fixed", "space_id": "s-fixed"}]
+    df = pd.DataFrame({"A": ["x", "y"], "B": ["p", "q"]})
+    client.spaces.create("t", df, {"A": DataType.Title, "B": DataType.Semantic},
+                         space_id="s-fixed", map_id="m-fixed", wait=False)
+    form = transport.calls[0]["kwargs"]["data"]
+    assert form["space_id"] == "s-fixed"
+    assert form["map_id"] == "m-fixed"

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -106,7 +106,21 @@ def test_create_passes_explicit_space_and_map_id(client, transport):
     transport.queue = [{"map_id": "m-fixed", "space_id": "s-fixed"}]
     df = pd.DataFrame({"A": ["x", "y"], "B": ["p", "q"]})
     client.spaces.create("t", df, {"A": DataType.Title, "B": DataType.Semantic},
-                         space_id="s-fixed", map_id="m-fixed", wait=False)
+                         space_id="s-fixed", map_id="m-fixed", map_name="My Map", wait=False)
     form = transport.calls[0]["kwargs"]["data"]
     assert form["space_id"] == "s-fixed"
     assert form["map_id"] == "m-fixed"
+    assert form["map_name"] == "My Map"
+
+
+def test_create_defaults_map_name_to_space_name(client, transport):
+    # without an explicit map_name the backend names the map "Untitled Map"; we default it to
+    # the space name so a single-map space gets a sensible label.
+    import pandas as pd
+
+    from mantis_sdk import DataType
+
+    transport.queue = [{"map_id": "m1", "space_id": "s1"}]
+    df = pd.DataFrame({"A": ["x"], "B": ["p"]})
+    client.spaces.create("My Space", df, {"A": DataType.Title, "B": DataType.Semantic}, wait=False)
+    assert transport.calls[0]["kwargs"]["data"]["map_name"] == "My Space"


### PR DESCRIPTION
This pull request introduces "Repo Radar," a comprehensive, headless, and scriptable intelligence tool for the Mantis project. It automates the creation of a weekly briefing by aggregating data from GitHub repositories and meeting notes, performing notebook-based delta analyses, synthesizing insights with an agent, and assembling the results into a markdown report. The workflow is designed to degrade gracefully if any stack is unavailable, and its automation covers use cases that the Mantis UI cannot handle.

Key additions and improvements include:

**New End-to-End Intelligence Workflow:**

* Added `repo_radar.py`, a script that orchestrates four phases: (1) building a portfolio of maps from project data, (2) running notebook delta analyses to track changes week-over-week, (3) synthesizing a briefing using an agent, and (4) assembling a markdown report with results and charts. The script is headless, scriptable, and supports scheduled runs.

**Documentation:**

* Introduced a detailed `README.md` for Repo Radar, explaining its purpose, the four-phase workflow, why it cannot be replicated in the Mantis UI, requirements, and instructions for running and configuring the tool via environment variables.